### PR TITLE
tests improved on consuming heap allocated iters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-iter"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A thread-safe, convenient and lightweight concurrent iterator trait and efficient implementations."

--- a/tests/consume_vec.rs
+++ b/tests/consume_vec.rs
@@ -48,3 +48,53 @@ fn consume_vec(len: usize, num_threads: usize, batch: usize) {
         concurrent_iter(num_threads, batch, source);
     }
 }
+
+fn concurrent_iter_heap(num_threads: usize, batch: usize, vec: Vec<String>) {
+    let iter = &vec.into_con_iter();
+
+    let some_str: String = std::thread::scope(|s| {
+        let mut handles = vec![];
+        for _ in 0..num_threads {
+            handles.push(s.spawn(move || {
+                let mut str = String::new();
+                if batch == 1 {
+                    while let Some(next) = iter.next_id_and_value() {
+                        str = next.value;
+                    }
+                } else {
+                    let mut more = true;
+                    while more {
+                        more = false;
+                        let (_begin_idx, iter) = iter.next_id_and_chunk(batch).into();
+                        for value in iter {
+                            str = value;
+                            more = true;
+                        }
+                    }
+                }
+                str
+            }));
+        }
+
+        handles
+            .into_iter()
+            .map(|x| x.join().expect("-"))
+            .filter(|x| !x.is_empty())
+            .last()
+            .unwrap()
+    });
+
+    assert!(!some_str.is_empty());
+}
+
+#[test_matrix(
+    [1, 2, 4, 8, 64, 1024, 64*1024],
+    [4 ,8, 16],
+    [1, 2, 4, 5, 8, 64, 71, 1024, 1025]
+)]
+fn consume_vec_heap(len: usize, num_threads: usize, batch: usize) {
+    for _ in 0..NUM_RERUNS {
+        let source: Vec<_> = (0..len).map(|x| x.to_string()).collect();
+        concurrent_iter_heap(num_threads, batch, source);
+    }
+}


### PR DESCRIPTION
Before experimenting to remove dependency on `Default` for consuming concurrent iterators, such as that on standard vector, it is important to have tests with heap allocated elements. Therefore, test coverage is increased with `String` as the example element type.