### PR TITLE
`ExactSizeConcurrentIter` is defined and implemented

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-iter"
-version = "1.0.3"
+version = "1.1.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A thread-safe, convenient and lightweight concurrent iterator trait and efficient implementations."
@@ -12,8 +12,9 @@ categories = ["data-structures", "concurrency", "rust-patterns"]
 [dependencies]
 
 [dev-dependencies]
-orx-concurrent-bag = "1.9"
-orx-fixed-vec = "2.7"
-orx-pinned-vec = "2.7"
-orx-split-vec = "2.8"
+orx-concurrent-bag = "1.11"
+orx-fixed-vec = "2.8"
+orx-pinned-concurrent-col = "1.0"
+orx-pinned-vec = "2.8"
+orx-split-vec = "2.9"
 test-case = "3.3.1"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A thread-safe, convenient and lightweight concurrent iterator trait and efficien
 * **convenient**: An iterator implementing `ConcurrentIter` can safely be shared among threads as a shared reference. Further, it may be used similar to a regular `Iterator` with `for` syntax.
 * **efficient** and **lightweight**: All concurrent iterator implementations provided in this crate extend atomic iterators, which are lock-free and depend only on atomic primitives.
 
-## A. Examples
+## Examples
 
 ### Basic Usage
 
@@ -186,13 +186,13 @@ for num_threads in [1, 2, 4, 8] {
 }
 ```
 
-Note that due to parallelization, `outputs` is not guaranteed to be in the same order as `inputs`. In order to preserve the order of the input in the output, [`ConcurrentIter::ids_and_values`] method can be used, rather than the `values`, to get indices of values while iterating (see the explanation in the next section).
+Note that due to parallelization, `outputs` is not guaranteed to be in the same order as `inputs`. In order to preserve the order of the input in the output, [`ConcurrentIter::ids_and_values`] method can be used, rather than the `values`, to get indices of values while iterating (see the explanation in the next section). Similarly, `ConcurrentBag` can be replaced with [`orx_concurrent_bag::ConcurrentOrderedBag`](https://crates.io/crates/orx-concurrent-ordered-bag) to guarantee that the order is preserved.
 
-## Iteration with Indices
+### Iteration with Indices
 
-In a single-threaded regular `Iterator`, values can be paired up with their indices easily by calling `enumerate` on the iterator. We can also call `rf_inputs.values().enumerate()`; however, this would have a different meaning in a multi-threaded execution. It would pair up the values with the indices of the iteration local to that thread. In other words, the first value of every thread will be paired up with index zero.
+In a single-threaded regular `Iterator`, values can be paired up with their indices easily by calling `enumerate` on the iterator. We can also call `inputs.values().enumerate()`; however, this would have a different meaning in a multi-threaded execution. It would pair up the values with the indices of the iteration local to that thread. In other words, the first value of every thread will zero.
 
-However, it is often useful to know the input index of the iteration value. This can be achieved simply by using [`ConcurrentIter::ids_and_values`] instead of [`ConcurrentIter::values`].
+Actual iteration index of values can be obtained simply by using [`ConcurrentIter::ids_and_values`] instead of [`ConcurrentIter::values`].
 
 ```rust
 use orx_concurrent_iter::*;
@@ -235,15 +235,17 @@ Notice that:
 * No index appears more than once in any of the `indices_for_thread` vectors.
 * And union of these vectors give the indices from 0 to `n-1` where n is the number of yielded elements.
 
-# Iteration in Chunks
+### Iteration in Chunks
 
 In the default iteration using `for` together with `values` and `ids_and_values` methods, the threads pull elements one by one. Note that these iterators internally call [`ConcurrentIter::next`] and [`ConcurrentIter::next_id_and_value`]  methods, respectively.
 
-Further, it is also possible to iterate in chunks with [`ConcurrentIter::next_chunk`] and [`ConcurrentIter::next_id_and_chunk`] methods. These methods differ from `next` and `next_id_and_value` in the following:
+Further, it is also possible to iterate in chunks with [`ConcurrentIter::next_chunk`] and [`ExactSizeConcurrentIter::next_exact_chunk`] methods. These methods differ from `next` and `next_id_and_value` in the following:
 * They receive the `chunk_size` parameter.
-* They return an `Iterator` which yields the next `chunk_size`, or fewer if there is not sufficient, **consecutive** elements.
-* `next_id_and_chunk` method additionally returns the index of the first element that the returned iterator will yield. Note that the index of the remaining elements can be known since the iterator will return consecutive elements.
+* They return an `Iterator` or `ExactSizeIterator` which yields the next `chunk_size` or fewer **consecutive** elements.
+* Further, they additionally return the index of the first element that the returned iterator will yield. Note that the index of the remaining elements can be known since the iterator will return consecutive elements.
 
+The advantage of `ExactSizeConcurrentIter` over `ConcurrentIter`, or `next_exact_chunk` over `next_chunk` is that it returns an iterator with an exact known size, which allows to return `None` when the iterator is empty. This has ergonomic benefits such as allowing `if let Some` or `while let Some` as demonstrated below. However, as expected, sources only with known lengths allow for it.
+ 
 ```rust
 use orx_concurrent_iter::*;
 
@@ -257,28 +259,18 @@ let characters = &inputs.con_iter();
 let [first, second] = std::thread::scope(|s| {
     let first = s.spawn(move || {
         let mut chars: Vec<char> = vec![];
-        loop {
-            let mut chunk = characters.next_chunk(3).peekable();
-            match chunk.peek() {
-                None => break,
-                Some(_) => chars.extend(chunk.copied()),
-            }
+        while let Some(chunk) = characters.next_exact_chunk(3) {
+            chars.extend(chunk.values().copied());
             lag(100);
         }
         chars
     });
 
     let second = s.spawn(move || {
+        lag(50);
         let mut chars: Vec<char> = vec![];
-        loop {
-            lag(50);
-
-            let mut chunk = characters.next_chunk(3).peekable();
-            match chunk.peek() {
-                None => break,
-                Some(_) => chars.extend(chunk.copied()),
-            }
-
+        while let Some(chunk) = characters.next_exact_chunk(3) {
+            chars.extend(chunk.values().copied());
             lag(100);
         }
         chars
@@ -298,7 +290,7 @@ assert_eq!(first, ['a', 'b', 'c', 'g', 'h']);
 assert_eq!(second, ['d', 'e', 'f']);
 ```
 
-## B. Traits and Implementors
+## Traits and Implementors
 
 As discussed so far, the trait of types which can safely be iterated concurrently by multiple threads is [`ConcurrentIter`].
 

--- a/tests/con_iter.rs
+++ b/tests/con_iter.rs
@@ -24,8 +24,9 @@ where
                     let mut more = true;
                     while more {
                         more = false;
-                        let (begin_idx, iter) = iter.next_id_and_chunk(batch).into();
-                        for (i, value) in iter.enumerate() {
+                        let next = iter.next_chunk(batch);
+                        let begin_idx = next.begin_idx();
+                        for (i, value) in next.values().enumerate() {
                             bag.push((begin_idx + i, value));
                             more = true;
                         }
@@ -61,7 +62,7 @@ where
                         let mut more = true;
                         while more {
                             more = false;
-                            for value in iter.next_chunk(batch) {
+                            for value in iter.next_chunk(batch).values() {
                                 sum = sum + value;
                                 more = true;
                             }

--- a/tests/consume_array.rs
+++ b/tests/consume_array.rs
@@ -20,8 +20,8 @@ fn concurrent_iter(num_threads: usize, batch: usize, array: [i64; 1024]) {
                     let mut more = true;
                     while more {
                         more = false;
-                        let (_begin_idx, iter) = iter.next_id_and_chunk(batch).into();
-                        for value in iter {
+                        let next = iter.next_chunk(batch);
+                        for value in next.values() {
                             sum += value;
                             more = true;
                         }

--- a/tests/consume_iter.rs
+++ b/tests/consume_iter.rs
@@ -24,8 +24,8 @@ fn concurrent_iter<I: Iterator<Item = i64>>(
                     let mut more = true;
                     while more {
                         more = false;
-                        let (_begin_idx, iter) = iter.next_id_and_chunk(batch).into();
-                        for value in iter {
+                        let next = iter.next_chunk(batch);
+                        for value in next.values() {
                             sum += value;
                             more = true;
                         }

--- a/tests/consume_vec.rs
+++ b/tests/consume_vec.rs
@@ -20,8 +20,8 @@ fn concurrent_iter(num_threads: usize, batch: usize, vec: Vec<i64>) {
                     let mut more = true;
                     while more {
                         more = false;
-                        let (_begin_idx, iter) = iter.next_id_and_chunk(batch).into();
-                        for value in iter {
+                        let next = iter.next_chunk(batch);
+                        for value in next.values() {
                             sum += value;
                             more = true;
                         }
@@ -65,8 +65,8 @@ fn concurrent_iter_heap(num_threads: usize, batch: usize, vec: Vec<String>) {
                     let mut more = true;
                     while more {
                         more = false;
-                        let (_begin_idx, iter) = iter.next_id_and_chunk(batch).into();
-                        for value in iter {
+                        let next = iter.next_chunk(batch);
+                        for value in next.values() {
                             str = value;
                             more = true;
                         }

--- a/tests/exact_con_iter.rs
+++ b/tests/exact_con_iter.rs
@@ -1,0 +1,75 @@
+use orx_concurrent_iter::*;
+use std::{fmt::Debug, ops::Add};
+
+fn validate_exact_iter<Fun, I>(get_iter: Fun, expected_len: usize)
+where
+    I: ExactSizeConcurrentIter,
+    I::Item: Debug + Add<usize, Output = usize>,
+    Fun: Fn() -> I,
+{
+    let iter = get_iter();
+    assert_eq!(iter.len(), expected_len);
+
+    for (idx, i) in iter.values().enumerate() {
+        assert_eq!(i + 0, idx);
+    }
+
+    let iter = get_iter();
+    for (idx, i) in iter.ids_and_values() {
+        assert_eq!(i + 0, idx);
+    }
+
+    let iter = get_iter();
+    while let Some(chunk) = iter.next_exact_chunk(7) {
+        let begin_idx = chunk.begin_idx();
+        for (idx, i) in chunk.values().enumerate() {
+            let idx = begin_idx + idx;
+            assert_eq!(i + 0, idx);
+        }
+    }
+
+    let iter = get_iter();
+    loop {
+        let chunk = iter.next_chunk(7);
+        let begin_idx = chunk.begin_idx();
+        let mut has_more = false;
+        for (idx, i) in chunk.values().enumerate() {
+            has_more = true;
+            let idx = begin_idx + idx;
+            assert_eq!(i + 0, idx);
+        }
+
+        if !has_more {
+            break;
+        }
+    }
+}
+
+#[test]
+fn exact_range() {
+    let range = 0..8564;
+    validate_exact_iter(|| range.clone().con_iter(), range.len());
+}
+
+#[test]
+fn exact_vec() {
+    let vec: Vec<_> = (0..8564).collect();
+    validate_exact_iter(|| vec.clone().into_con_iter(), vec.len());
+}
+
+#[test]
+fn exact_slice() {
+    let vec: Vec<_> = (0..8564).collect();
+    validate_exact_iter(|| vec.con_iter(), vec.len());
+    validate_exact_iter(|| vec.as_slice().into_con_iter(), vec.len());
+}
+
+#[test]
+fn exact_array() {
+    let mut array = [0usize; 1587];
+    for (i, x) in array.iter_mut().enumerate() {
+        *x = i;
+    }
+    validate_exact_iter(|| array.con_iter(), array.len());
+    validate_exact_iter(|| array.into_con_iter(), array.len());
+}


### PR DESCRIPTION
* `ExactSizeConcurrentIter` trait is defined. This allows to know exactly the length of a chunk when we are iterating with chunks using the `next_exact_chunk` method. This is a very important method for parallel computing when the iterator is composed with a concurrent bag, because it allows to buffer inputs (without allocating, just reserve indices) and allows to deal with false sharing issue.
* Furthermore, exact size iterator leads to much nicer ergonomics allowing `while let Some` loops, while without the exact iterator one needs to check whether the chunk is empty or not by iterating on it.
* In order to achieve this `fetch_n_with_exact_len` method is added to atomic iterator trait.
* Corresponding exact size implementations are provided by range, vec, array and slice.
* Documentation is revised accordingly.
* Tests are extended to cover the exact size iterators.