### PR TITLE
IntoExactSizeConcurrentIter requires IntoConcurrentIter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-iter"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A thread-safe, convenient and lightweight concurrent iterator trait and efficient implementations."

--- a/src/iter/constructors/implementors/array.rs
+++ b/src/iter/constructors/implementors/array.rs
@@ -29,12 +29,8 @@ impl<const N: usize, T: Send + Sync + Default> IntoConcurrentIter for [T; N] {
 }
 
 impl<const N: usize, T: Send + Sync + Default> IntoExactSizeConcurrentIter for [T; N] {
-    type Item = T;
-
-    type ExactConIter = ConIterOfArray<N, T>;
-
-    fn into_exact_con_iter(self) -> Self::ExactConIter {
-        Self::ExactConIter::new(self)
+    fn into_exact_con_iter(self) -> Self::ConIter {
+        Self::ConIter::new(self)
     }
 
     fn exact_len(&self) -> usize {

--- a/src/iter/constructors/implementors/range.rs
+++ b/src/iter/constructors/implementors/range.rs
@@ -63,12 +63,8 @@ where
         + Sub<Idx, Output = Idx>
         + Ord,
 {
-    type Item = Idx;
-
-    type ExactConIter = ConIterOfRange<Idx>;
-
-    fn into_exact_con_iter(self) -> Self::ExactConIter {
-        Self::ExactConIter::new(self)
+    fn into_exact_con_iter(self) -> Self::ConIter {
+        Self::ConIter::new(self)
     }
 
     fn exact_len(&self) -> usize {

--- a/src/iter/constructors/implementors/slice.rs
+++ b/src/iter/constructors/implementors/slice.rs
@@ -28,12 +28,8 @@ impl<'a, T: Send + Sync> IntoConcurrentIter for &'a [T] {
 }
 
 impl<'a, T: Send + Sync> IntoExactSizeConcurrentIter for &'a [T] {
-    type Item = &'a T;
-
-    type ExactConIter = ConIterOfSlice<'a, T>;
-
-    fn into_exact_con_iter(self) -> Self::ExactConIter {
-        Self::ExactConIter::new(self)
+    fn into_exact_con_iter(self) -> Self::ConIter {
+        Self::ConIter::new(self)
     }
 
     fn exact_len(&self) -> usize {

--- a/src/iter/constructors/implementors/vec.rs
+++ b/src/iter/constructors/implementors/vec.rs
@@ -27,12 +27,8 @@ impl<T: Send + Sync + Default> IntoConcurrentIter for Vec<T> {
 }
 
 impl<T: Send + Sync + Default> IntoExactSizeConcurrentIter for Vec<T> {
-    type Item = T;
-
-    type ExactConIter = ConIterOfVec<T>;
-
-    fn into_exact_con_iter(self) -> Self::ExactConIter {
-        Self::ExactConIter::new(self)
+    fn into_exact_con_iter(self) -> Self::ConIter {
+        Self::ConIter::new(self)
     }
 
     fn exact_len(&self) -> usize {

--- a/src/iter/constructors/into_exact_con_iter.rs
+++ b/src/iter/constructors/into_exact_con_iter.rs
@@ -1,15 +1,12 @@
-use crate::ExactSizeConcurrentIter;
+use crate::{ExactSizeConcurrentIter, IntoConcurrentIter};
 
 /// A type that can be consumed and turned into an exact size concurrent iterator with `into_exact_con_iter` method.
-pub trait IntoExactSizeConcurrentIter {
-    /// Type of the items that the iterator yields.
-    type Item;
-
-    /// Concurrent iterator that this type will be converted into with the `into_exact_con_iter` method.
-    type ExactConIter: ExactSizeConcurrentIter<Item = Self::Item>;
-
+pub trait IntoExactSizeConcurrentIter: IntoConcurrentIter
+where
+    Self::ConIter: ExactSizeConcurrentIter<Item = Self::Item>,
+{
     /// Consumes this type and converts it into an exact size concurrent iterator.
-    fn into_exact_con_iter(self) -> Self::ExactConIter;
+    fn into_exact_con_iter(self) -> Self::ConIter;
 
     /// Returns the exact remaining length of the exact size concurrent iterator, before converting it into the iterator.
     fn exact_len(&self) -> usize;


### PR DESCRIPTION
Trait definition is changed as follows `trait IntoExactSizeConcurrentIter: IntoConcurrentIter` which follows the similar to pattern as iterator and exact-size-iterator.