### PR TITLE
Concurrent `fold`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "orx-concurrent-iter"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
-description = "A thread-safe, convenient and lightweight concurrent iterator trait and efficient implementations."
+description = "A thread-safe, ergonomic and lightweight concurrent iterator trait and efficient implementations."
 license = "MIT"
 repository = "https://github.com/orxfun/orx-concurrent-iter/"
 keywords = ["concurrency", "iterator", "iteration", "atomic", "parallelism"]

--- a/src/iter/atomic_iter.rs
+++ b/src/iter/atomic_iter.rs
@@ -40,6 +40,81 @@ pub trait AtomicIter<T: Send + Sync>: Send + Sync {
     /// Calling thread will process one input at a time ([`AtomicIter::fetch_one`]) when `n` is set to 1.
     /// Alternatively, each thread might process `n` consecutive elements at each iteration ([`AtomicIter::fetch_n`]).
     fn enumerate_for_each_n<F: FnMut(usize, T)>(&self, n: usize, f: F);
+
+    /// Folds the elements of the iterator pulled concurrently using `fold` function.
+    ///
+    /// Note that this method might be called on the same iterator at the same time from different threads.
+    /// Each thread will start its concurrent fold operation with the `neutral` value.
+    /// This value is then transformed into the result by applying the `fold` on it together with the pulled elements.
+    ///
+    /// Therefore, each thread will end up at a different partial result.
+    /// Further, each thread's partial result might be different in every execution.
+    /// However, once `fold` is applied starting again from `neutral` using the thread results will lead to the deterministic result which would have been obtained in sequential operation.
+    /// This establishes a very ergonomic parallel fold implementation.
+    ///
+    /// # Examples
+    ///
+    /// Notice that the initial value is called `neutral` as in **monoids**, rather than init or initial.
+    /// This is to highlight that each thread will start its separate execution from this value.
+    ///
+    /// ### Good Example with a Neutral Element
+    ///
+    /// Integer addition and number zero are good examples for `neutral` and `fold`, respectively.
+    /// Assume our iterator will yield 4 values: [3, 4, 1, 9].
+    /// We want to sum these values using two threads.
+    /// We can achieve parallelism very conveniently using `fold` as follows.
+    ///
+    /// ```rust
+    /// use orx_concurrent_iter::*;
+    ///
+    /// let num_threads = 2;
+    ///
+    /// let numbers = vec![3, 4, 1, 9];
+    /// let slice = numbers.as_slice();
+    /// let iter = &slice.con_iter();
+    ///
+    /// let neutral = 0; // neutral for i32 & add
+    ///
+    /// let sum = std::thread::scope(|s| {
+    ///     (0..num_threads)
+    ///         .map(|_| s.spawn(move || iter.fold(1, neutral, |x, y| x + y))) // parallel fold
+    ///         .map(|x| x.join().unwrap())
+    ///         .fold(neutral, |x, y| x + y) // sequential fold
+    /// });
+    ///
+    /// assert_eq!(sum, 17);
+    /// ```
+    ///
+    /// Note that this code can execute in one of many possible ways.
+    /// Let's say our two threads are called tA and tB.
+    /// * tA might pull and sum all four of the numbers; hence, returns 17. tB cannot pull any element and just returns the neutral element. Sequential fold will add 17 and 0, and return 17.
+    /// * tA might pull only the third element; hence, returns 0+1 = 1. tB pulls the other 3 elements and returns 0+3+4+9 = 16. Final fold will then return 0+1+16 = 17.
+    /// * and so on, so forth.
+    ///
+    /// `ConcurrentIter` guarantees that each element is visited and computed exactly once.
+    /// Therefore, the parallel computation will always be correct provided that we provide a neutral element such that:
+    ///
+    /// ```rust ignore
+    /// assert_eq!(fold(neutral, element), element);
+    /// ```
+    ///
+    /// Other trivial examples are:
+    /// * `1` & multiplication
+    /// * empty string/list & string/list concat
+    /// * `true` & logical, etc.
+    ///
+    /// ## Wrong Example with a Non-Neutral Element
+    ///
+    /// In a sequential fold operation, once can start the summation above with an initial value of 100.
+    /// Then, the resulting value would deterministically be 117.
+    ///
+    /// However, if we pass 100 as the neutral element to the concurrent fold above, we would receive 217 (additional 100 for each thread).
+    /// Notice that the result depends on the number of threads used in computation.
+    /// This is incorrect.
+    ///
+    /// In either case, it is a good practice to leave 100 out of the fold operation.
+    /// Ideally, we would pass 0 as the initial and neutral element, and add 100 to the result of the fold operation.
+    fn fold<B, Fold: FnMut(B, T) -> B>(&self, chunk_size: usize, neutral: B, fold: Fold) -> B;
 }
 
 /// An atomic counter based iterator with exactly known initial length.

--- a/src/iter/default_fns/fold.rs
+++ b/src/iter/default_fns/fold.rs
@@ -1,0 +1,64 @@
+use crate::{ConcurrentIter, ExactSizeConcurrentIter, NextChunk};
+
+// ANY
+pub(crate) fn any_fold<I, F, B>(iter: &I, chunk_size: usize, f: F, initial: B) -> B
+where
+    I: ConcurrentIter,
+    F: FnMut(B, I::Item) -> B,
+{
+    assert!(chunk_size > 0, "Chunk size must be positive.");
+    let mut f = f;
+
+    let mut result = initial;
+
+    match chunk_size {
+        1 => {
+            while let Some(value) = iter.next() {
+                result = f(result, value);
+            }
+        }
+        _ => loop {
+            let next = iter.next_chunk(chunk_size);
+            let mut has_any = false;
+            for value in next.values() {
+                has_any = true;
+                result = f(result, value);
+            }
+
+            if !has_any {
+                break;
+            }
+        },
+    }
+
+    result
+}
+
+// EXACT
+pub(crate) fn exact_fold<I, F, B>(iter: &I, chunk_size: usize, f: F, initial: B) -> B
+where
+    I: ExactSizeConcurrentIter,
+    F: FnMut(B, I::Item) -> B,
+{
+    assert!(chunk_size > 0, "Chunk size must be positive.");
+    let mut f = f;
+
+    let mut result = initial;
+
+    match chunk_size {
+        1 => {
+            while let Some(value) = iter.next() {
+                result = f(result, value);
+            }
+        }
+        _ => {
+            while let Some(next) = iter.next_exact_chunk(chunk_size) {
+                for value in next.values() {
+                    result = f(result, value);
+                }
+            }
+        }
+    }
+
+    result
+}

--- a/src/iter/default_fns/mod.rs
+++ b/src/iter/default_fns/mod.rs
@@ -1,1 +1,2 @@
+pub mod fold;
 pub mod for_each;

--- a/src/iter/implementors/array.rs
+++ b/src/iter/implementors/array.rs
@@ -69,6 +69,11 @@ impl<const N: usize, T: Send + Sync + Default> AtomicIter<T> for ConIterOfArray<
     fn enumerate_for_each_n<F: FnMut(usize, T)>(&self, chunk_size: usize, f: F) {
         default_fns::for_each::exact_for_each_with_ids(self, chunk_size, f)
     }
+
+    #[inline(always)]
+    fn fold<B, F: FnMut(B, T) -> B>(&self, chunk_size: usize, initial: B, f: F) -> B {
+        default_fns::fold::exact_fold(self, chunk_size, f, initial)
+    }
 }
 
 impl<const N: usize, T: Send + Sync + Default> AtomicIterWithInitialLen<T>
@@ -126,6 +131,14 @@ impl<const N: usize, T: Send + Sync + Default> ConcurrentIter for ConIterOfArray
     #[inline(always)]
     fn enumerate_for_each_n<F: FnMut(usize, Self::Item)>(&self, chunk_size: usize, f: F) {
         <Self as AtomicIter<_>>::enumerate_for_each_n(self, chunk_size, f)
+    }
+
+    #[inline(always)]
+    fn fold<B, Fold>(&self, chunk_size: usize, neutral: B, fold: Fold) -> B
+    where
+        Fold: FnMut(B, Self::Item) -> B,
+    {
+        <Self as AtomicIter<_>>::fold(self, chunk_size, neutral, fold)
     }
 }
 

--- a/src/iter/implementors/iter.rs
+++ b/src/iter/implementors/iter.rs
@@ -113,6 +113,11 @@ where
     fn enumerate_for_each_n<F: FnMut(usize, T)>(&self, chunk_size: usize, f: F) {
         default_fns::for_each::any_for_each_with_ids(self, chunk_size, f)
     }
+
+    #[inline(always)]
+    fn fold<B, F: FnMut(B, T) -> B>(&self, chunk_size: usize, initial: B, f: F) -> B {
+        default_fns::fold::any_fold(self, chunk_size, f, initial)
+    }
 }
 
 unsafe impl<T: Send + Sync, Iter> Sync for ConIterOfIter<T, Iter> where Iter: Iterator<Item = T> {}
@@ -145,5 +150,13 @@ where
     #[inline(always)]
     fn enumerate_for_each_n<F: FnMut(usize, Self::Item)>(&self, chunk_size: usize, f: F) {
         <Self as AtomicIter<_>>::enumerate_for_each_n(self, chunk_size, f)
+    }
+
+    #[inline(always)]
+    fn fold<B, Fold>(&self, chunk_size: usize, neutral: B, fold: Fold) -> B
+    where
+        Fold: FnMut(B, Self::Item) -> B,
+    {
+        <Self as AtomicIter<_>>::fold(self, chunk_size, neutral, fold)
     }
 }

--- a/src/iter/implementors/range.rs
+++ b/src/iter/implementors/range.rs
@@ -106,6 +106,11 @@ where
     fn enumerate_for_each_n<F: FnMut(usize, Idx)>(&self, chunk_size: usize, f: F) {
         default_fns::for_each::exact_for_each_with_ids(self, chunk_size, f)
     }
+
+    #[inline(always)]
+    fn fold<B, F: FnMut(B, Idx) -> B>(&self, chunk_size: usize, initial: B, f: F) -> B {
+        default_fns::fold::exact_fold(self, chunk_size, f, initial)
+    }
 }
 
 impl<Idx> AtomicIterWithInitialLen<Idx> for ConIterOfRange<Idx>
@@ -206,6 +211,14 @@ where
     #[inline(always)]
     fn enumerate_for_each_n<F: FnMut(usize, Self::Item)>(&self, chunk_size: usize, f: F) {
         <Self as AtomicIter<_>>::enumerate_for_each_n(self, chunk_size, f)
+    }
+
+    #[inline(always)]
+    fn fold<B, Fold>(&self, chunk_size: usize, neutral: B, fold: Fold) -> B
+    where
+        Fold: FnMut(B, Self::Item) -> B,
+    {
+        <Self as AtomicIter<_>>::fold(self, chunk_size, neutral, fold)
     }
 }
 

--- a/src/iter/implementors/slice.rs
+++ b/src/iter/implementors/slice.rs
@@ -71,6 +71,11 @@ impl<'a, T: Send + Sync> AtomicIter<&'a T> for ConIterOfSlice<'a, T> {
     fn enumerate_for_each_n<F: FnMut(usize, &'a T)>(&self, chunk_size: usize, f: F) {
         default_fns::for_each::exact_for_each_with_ids(self, chunk_size, f)
     }
+
+    #[inline(always)]
+    fn fold<B, F: FnMut(B, &'a T) -> B>(&self, chunk_size: usize, initial: B, f: F) -> B {
+        default_fns::fold::exact_fold(self, chunk_size, f, initial)
+    }
 }
 
 impl<'a, T: Send + Sync> AtomicIterWithInitialLen<&'a T> for ConIterOfSlice<'a, T> {
@@ -125,6 +130,14 @@ impl<'a, T: Send + Sync> ConcurrentIter for ConIterOfSlice<'a, T> {
     #[inline(always)]
     fn enumerate_for_each_n<F: FnMut(usize, Self::Item)>(&self, chunk_size: usize, f: F) {
         <Self as AtomicIter<_>>::enumerate_for_each_n(self, chunk_size, f)
+    }
+
+    #[inline(always)]
+    fn fold<B, Fold>(&self, chunk_size: usize, neutral: B, fold: Fold) -> B
+    where
+        Fold: FnMut(B, Self::Item) -> B,
+    {
+        <Self as AtomicIter<_>>::fold(self, chunk_size, neutral, fold)
     }
 }
 

--- a/src/iter/implementors/vec.rs
+++ b/src/iter/implementors/vec.rs
@@ -70,6 +70,11 @@ impl<T: Send + Sync + Default> AtomicIter<T> for ConIterOfVec<T> {
     fn enumerate_for_each_n<F: FnMut(usize, T)>(&self, chunk_size: usize, f: F) {
         default_fns::for_each::exact_for_each_with_ids(self, chunk_size, f)
     }
+
+    #[inline(always)]
+    fn fold<B, F: FnMut(B, T) -> B>(&self, chunk_size: usize, initial: B, f: F) -> B {
+        default_fns::fold::exact_fold(self, chunk_size, f, initial)
+    }
 }
 
 impl<T: Send + Sync + Default> AtomicIterWithInitialLen<T> for ConIterOfVec<T> {
@@ -125,6 +130,14 @@ impl<T: Send + Sync + Default> ConcurrentIter for ConIterOfVec<T> {
     #[inline(always)]
     fn enumerate_for_each_n<F: FnMut(usize, Self::Item)>(&self, chunk_size: usize, f: F) {
         <Self as AtomicIter<_>>::enumerate_for_each_n(self, chunk_size, f)
+    }
+
+    #[inline(always)]
+    fn fold<B, Fold>(&self, chunk_size: usize, neutral: B, fold: Fold) -> B
+    where
+        Fold: FnMut(B, Self::Item) -> B,
+    {
+        <Self as AtomicIter<_>>::fold(self, chunk_size, neutral, fold)
     }
 }
 


### PR DESCRIPTION
* Concurrent `fold` method is added to `ConcurrentIter` trait methods.
* Two default implementations (one for exact size iterators, one for any) are provided.