### PR TITLE
Cloned iterator over slice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-iter"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A thread-safe, ergonomic and lightweight concurrent iterator trait and efficient implementations."

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 A thread-safe, ergonomic and lightweight concurrent iterator trait and efficient implementations.
 
-* **ergonomic**: An iterator implementing `ConcurrentIter` can safely be shared among threads as a shared reference. It may be iterated over concurrently from multiple threads with `for` syntax. It further provides higher level methods such as `for_each` and `fold` which allow for safe, simple and efficient parallelism.
-* **efficient** and **lightweight**: All concurrent iterator implementations provided in this crate extend atomic iterators, which are lock-free and depend only on atomic primitives.
+* **ergonomic**: An iterator implementing `ConcurrentIter` can safely be shared among threads. It may be iterated over concurrently from multiple threads with `for` or `while let`. It further provides higher level methods such as `for_each` and `fold` which allow for safe, simple and efficient parallelism.
+* **efficient** and **lightweight**: All concurrent iterator implementations provided in this crate extend atomic iterators which are lock-free and depend only on atomic primitives.
 
 ## Examples
 
@@ -314,13 +314,13 @@ Further, there are two traits which define types that can provide a `ConcurrentI
 
 The following table summarizes the implementations of the standard types in this crate.
 
-| Type | ConcurrentIterable <br/> `con_iter` element type | IntoConcurrentIter <br/> `into_con_iter` element type |
-|---|---|---|
-| `&'a [T]` | `&'a T` | `&'a T` |
-| `Range<Idx>` | `Idx` | `Idx` |
-| `Vec<T>` | `&T` | `T` |
-| `[T; N]` | `&T` | `T` |
-| `Iter: Iterator<Item = T>` | - | `T` |
+| Type | ConcurrentIterable <br/> `con_iter()` element type | IntoConcurrentIter <br/> `into_con_iter()` element type | Cloned <br/> `con_iter().cloned()` |
+|---|---|---|---|
+| `&'a [T]` | `&'a T` | `&'a T` | `T` |
+| `Range<Idx>` | `Idx` | `Idx` | |
+| `Vec<T>` | `&T` | `T` | |
+| `[T; N]` | `&T` | `T` | |
+| `Iter: Iterator<Item = T>` | - | `T` | |
 
 
 ## License

--- a/src/iter/default_fns/mod.rs
+++ b/src/iter/default_fns/mod.rs
@@ -1,2 +1,5 @@
 pub mod fold;
 pub mod for_each;
+
+#[cfg(test)]
+mod tests;

--- a/src/iter/default_fns/tests/fold.rs
+++ b/src/iter/default_fns/tests/fold.rs
@@ -1,0 +1,49 @@
+use crate::iter::default_fns;
+use crate::*;
+use test_case::test_matrix;
+
+#[test_matrix(
+    [8, 64, 256],
+    [4, 8, 16]
+)]
+fn any_fold(len: usize, chunk_size: usize) {
+    let numbers: Vec<_> = (0..len).collect();
+    let expected: i64 = numbers.iter().skip(1).take(len - 1).sum::<usize>() as i64;
+
+    let iter = numbers.iter().skip(1).take(len - 1);
+    let con_iter = iter.into_con_iter();
+    let sum = default_fns::fold::any_fold(&con_iter, chunk_size, |a, b| a + *b as i64, 0i64);
+
+    assert_eq!(sum, expected);
+}
+
+#[test_matrix(
+    [8, 64, 256],
+    [4, 8, 16]
+)]
+fn exact_fold(len: usize, chunk_size: usize) {
+    let numbers: Vec<_> = (0..len).collect();
+    let expected = numbers.iter().sum::<usize>() as i64;
+
+    let sum =
+        default_fns::fold::exact_fold(&numbers.con_iter(), chunk_size, |a, b| a + *b as i64, 0i64);
+
+    assert_eq!(sum, expected);
+}
+
+// panics
+#[test]
+#[should_panic]
+fn panics_any_fold() {
+    let numbers: Vec<_> = (0..64).collect();
+    let iter = numbers.iter().skip(1).take(8);
+    let con_iter = iter.into_con_iter();
+    let _ = default_fns::fold::any_fold(&con_iter, 0, |a, b| a + *b as i64, 0i64);
+}
+
+#[test]
+#[should_panic]
+fn panics_exact_fold() {
+    let numbers: Vec<_> = (0..64).collect();
+    let _ = default_fns::fold::exact_fold(&numbers.con_iter(), 0, |a, b| a + *b as i64, 0i64);
+}

--- a/src/iter/default_fns/tests/for_each.rs
+++ b/src/iter/default_fns/tests/for_each.rs
@@ -1,0 +1,121 @@
+use crate::iter::default_fns;
+use crate::*;
+use test_case::test_matrix;
+
+#[test_matrix(
+    [8, 64, 256],
+    [4, 8, 16]
+)]
+fn any_for_each(len: usize, chunk_size: usize) {
+    let numbers: Vec<_> = (0..len).collect();
+    let expected: usize = numbers.iter().skip(1).take(len - 1).sum();
+    let mut sum = 0;
+
+    let iter = numbers.iter().skip(1).take(len - 1);
+    let con_iter = iter.into_con_iter();
+    default_fns::for_each::any_for_each(&con_iter, chunk_size, |x| {
+        sum += x;
+    });
+
+    assert_eq!(sum, expected);
+}
+
+#[test_matrix(
+    [1, 8, 64, 256],
+    [4, 8, 16]
+)]
+fn any_for_each_with_ids(len: usize, chunk_size: usize) {
+    let numbers: Vec<_> = (0..len).collect();
+    let expected: usize = numbers.iter().sum();
+    let mut sum = 0;
+    let mut indices = 0;
+
+    let con_iter = numbers.into_con_iter();
+    default_fns::for_each::any_for_each_with_ids(&con_iter, chunk_size, |i, x| {
+        sum += x;
+        indices -= i as i64;
+    });
+
+    assert_eq!(sum, expected);
+    assert_eq!(indices, -(expected as i64));
+}
+
+#[test_matrix(
+    [8, 64, 256],
+    [4, 8, 16]
+)]
+fn exact_for_each(len: usize, chunk_size: usize) {
+    let numbers: Vec<_> = (0..len).collect();
+    let expected: usize = numbers.iter().sum();
+    let mut sum = 0;
+
+    default_fns::for_each::exact_for_each(&numbers.con_iter(), chunk_size, |x| {
+        sum += x;
+    });
+
+    assert_eq!(sum, expected);
+}
+
+#[test_matrix(
+    [8, 64, 256],
+    [4, 8, 16]
+)]
+fn exact_for_each_with_ids(len: usize, chunk_size: usize) {
+    let numbers: Vec<_> = (0..len).collect();
+    let expected: usize = numbers.iter().sum();
+    let mut sum = 0;
+    let mut indices = 0;
+
+    default_fns::for_each::exact_for_each_with_ids(&numbers.con_iter(), chunk_size, |i, x| {
+        sum += x;
+        indices -= i as i64;
+    });
+
+    assert_eq!(sum, expected);
+    assert_eq!(indices, -(expected as i64));
+}
+
+// panics
+#[test]
+#[should_panic]
+fn panics_any_for_each() {
+    let numbers: Vec<_> = (0..64).collect();
+    let mut sum = 0;
+    let iter = numbers.iter().skip(1).take(8);
+    let con_iter = iter.into_con_iter();
+    default_fns::for_each::any_for_each(&con_iter, 0, |x| {
+        sum += x;
+    });
+}
+
+#[test]
+#[should_panic]
+fn panics_any_for_each_with_ids() {
+    let numbers: Vec<_> = (0..64).collect();
+    let mut sum = 0;
+    let iter = numbers.iter().skip(1).take(8);
+    let con_iter = iter.into_con_iter();
+    default_fns::for_each::any_for_each_with_ids(&con_iter, 0, |_i, x| {
+        sum += x;
+    });
+}
+
+#[test]
+#[should_panic]
+fn panics_exact_for_each() {
+    let numbers: Vec<_> = (0..64).collect();
+    let mut sum = 0;
+    default_fns::for_each::exact_for_each(&numbers.con_iter(), 0, |x| {
+        sum += x;
+    });
+}
+
+#[test]
+#[should_panic]
+fn panics_exact_for_each_with_ids() {
+    let numbers: Vec<_> = (0..64).collect();
+    let mut sum = 0;
+    default_fns::for_each::exact_for_each_with_ids(&numbers.con_iter(), 0, |_i, x| {
+        sum += x;
+    });
+}

--- a/src/iter/default_fns/tests/mod.rs
+++ b/src/iter/default_fns/tests/mod.rs
@@ -1,0 +1,2 @@
+mod fold;
+mod for_each;

--- a/src/iter/implementors/cloned/mod.rs
+++ b/src/iter/implementors/cloned/mod.rs
@@ -1,0 +1,1 @@
+pub mod slice;

--- a/src/iter/implementors/mod.rs
+++ b/src/iter/implementors/mod.rs
@@ -1,4 +1,5 @@
 pub mod array;
+pub mod cloned;
 pub mod iter;
 pub mod range;
 pub mod slice;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,16 +3,16 @@
 //! [![orx-concurrent-iter crate](https://img.shields.io/crates/v/orx-concurrent-iter.svg)](https://crates.io/crates/orx-concurrent-iter)
 //! [![orx-concurrent-iter documentation](https://docs.rs/orx-concurrent-iter/badge.svg)](https://docs.rs/orx-concurrent-iter)
 //!
-//! A thread-safe, convenient and lightweight concurrent iterator trait and efficient implementations.
+//! A thread-safe, ergonomic and lightweight concurrent iterator trait and efficient implementations.
 //!
-//! * **convenient**: An iterator implementing `ConcurrentIter` can safely be shared among threads as a shared reference. Further, it may be used similar to a regular `Iterator` with `for` syntax.
-//! * **efficient** and **lightweight**: All concurrent iterator implementations provided in this crate extend atomic iterators, which are lock-free and depend only on atomic primitives.
+//! * **ergonomic**: An iterator implementing `ConcurrentIter` can safely be shared among threads. It may be iterated over concurrently from multiple threads with `for` or `while let`. It further provides higher level methods such as `for_each` and `fold` which allow for safe, simple and efficient parallelism.
+//! * **efficient** and **lightweight**: All concurrent iterator implementations provided in this crate extend atomic iterators which are lock-free and depend only on atomic primitives.
 //!
 //! ## Examples
 //!
 //! ### Basic Usage
 //!
-//! A `ConcurrentIter` can be safely shared among threads and iterated over concurrently. As expected, it will yield each element only once and in order. The yielded elements will be shared among the threads which concurrently iterates based on first come first serve. In other words, threads concurrently pull elements from the iterator.
+//! A `ConcurrentIter` can be safely shared among threads and iterated over concurrently. As expected, it will yield each element only once and in order. The yielded elements will be shared among the threads which concurrently iterates based on first come first serve. In other words, threads concurrently pull remaining elements from the iterator.
 //!
 //! ```rust
 //! use orx_concurrent_iter::*;
@@ -33,13 +33,13 @@
 //!     ConIter: ConcurrentIter<Item = T>,
 //! {
 //!     // just take a reference and share among threads
-//!     let con_iter = &concurrent_iter;
+//!     let iter = &concurrent_iter;
 //!
 //!     std::thread::scope(|s| {
 //!         for _ in 0..num_threads {
 //!             s.spawn(move || {
 //!                 // concurrently iterate over values in a `for` loop
-//!                 for value in con_iter.values() {
+//!                 for value in iter.values() {
 //!                     process(value);
 //!                 }
 //!             });
@@ -48,8 +48,8 @@
 //! }
 //!
 //! /// just fix process and num_threads for brevity
-//! fn con_run<T: Send + Sync + Debug>(con_iter: impl ConcurrentIter<Item = T>) {
-//!     process_concurrently(&fake_work, 8, con_iter)
+//! fn con_run<T: Send + Sync + Debug>(concurrent_iter: impl ConcurrentIter<Item = T>) {
+//!     process_concurrently(&fake_work, 8, concurrent_iter)
 //! }
 //!
 //! // non-consuming iteration over references
@@ -94,15 +94,15 @@
 //! }
 //! ```
 //!
-//! The `values` method returns a regular `Iterator` which does nothing but wrap the `ConcurrentIter` and call `next`. Its only purpose is to enable using the concurrent iterator directly inside a `for` loop.
+//! Or even with `for` loop using the `values` method:
 //!
 //! ```rust ignore
-//! for value in rf_con_iter.values() {
+//! for value in con_iter.values() {
 //!     process(value);
 //! }
 //! ```
 //!
-//! ### Simple Parallel Computing
+//! ### Parallel Computing, Almost Trivial
 //!
 //! Considering the elements of the iteration as inputs of a process, `ConcurrentIter` conveniently allows distribution of tasks to multiple threads.
 //!
@@ -145,7 +145,21 @@
 //! }
 //! ```
 //!
-//! Note that parallel map can also be implemented by merging returned transformed collections, such as vectors. Especially for larger data types, a more efficient approach could be to pair `ConcurrentIter` with a concurrent collection such as [`orx_concurrent_bag::ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) which allows to efficiently collect results concurrently without copies.
+//! Higher level functions may provide further simplifications. For instance, the `handles` above could also be collected as follows using the concurrent `fold` method:
+//!
+//! ```rust ignore
+//! fn map_fold(aggregated: u64, input: u64) -> u64 {
+//!     fold(aggregated, compute(input))
+//! }
+//!
+//! // ...
+//!
+//! let handles: Vec<_> = (0..num_threads)
+//!     .map(|_| s.spawn(move || inputs.fold(1, 0u64, map_fold)))
+//!     .collect();
+//! ```
+//!
+//! Parallel map can also be implemented by merging returned transformed collections, such as vectors. Especially for larger data types, a more efficient approach could be to pair `ConcurrentIter` with a concurrent collection such as [`orx_concurrent_bag::ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) which allows to efficiently collect results concurrently without copies.
 //!
 //! ```rust
 //! use orx_concurrent_iter::*;
@@ -190,7 +204,7 @@
 //!
 //! ### Iteration with Indices
 //!
-//! In a single-threaded regular `Iterator`, values can be paired up with their indices easily by calling `enumerate` on the iterator. We can also call `inputs.values().enumerate()`; however, this would have a different meaning in a multi-threaded execution. It would pair up the values with the indices of the iteration local to that thread. In other words, the first value of every thread will zero.
+//! In a single-threaded regular `Iterator`, values can be paired up with their indices easily by calling `enumerate` on the iterator. We can also call `inputs.values().enumerate()`; however, this would have a different meaning in a multi-threaded execution. It would pair up the values with the indices of the iteration local to that thread. In other words, the first value of every thread will be zero.
 //!
 //! Actual iteration index of values can be obtained simply by using [`ConcurrentIter::ids_and_values`] instead of [`ConcurrentIter::values`].
 //!
@@ -237,9 +251,9 @@
 //!
 //! ### Iteration in Chunks
 //!
-//! In the default iteration using `for` together with `values` and `ids_and_values` methods, the threads pull elements one by one. Note that these iterators internally call [`ConcurrentIter::next`] and [`ConcurrentIter::next_id_and_value`]  methods, respectively.
+//! In the default iteration using `for` together with `values` and `ids_and_values` methods, the threads pull elements one by one. Note that these iterators internally call `ConcurrentIter::next` and `ConcurrentIter::next_id_and_value` methods, respectively.
 //!
-//! Further, it is also possible to iterate in chunks with [`ConcurrentIter::next_chunk`] and [`ExactSizeConcurrentIter::next_exact_chunk`] methods. These methods differ from `next` and `next_id_and_value` in the following:
+//! Further, it is also possible to iterate in chunks with `ConcurrentIter::next_chunk` and `ExactSizeConcurrentIter::next_exact_chunk` methods. These methods differ from `next` and `next_id_and_value` in the following:
 //! * They receive the `chunk_size` parameter.
 //! * They return an `Iterator` or `ExactSizeIterator` which yields the next `chunk_size` or fewer **consecutive** elements.
 //! * Further, they additionally return the index of the first element that the returned iterator will yield. Note that the index of the remaining elements can be known since the iterator will return consecutive elements.
@@ -292,21 +306,21 @@
 //!
 //! ## Traits and Implementors
 //!
-//! As discussed so far, the trait of types which can safely be iterated concurrently by multiple threads is [`ConcurrentIter`].
+//! As discussed so far, the trait defining types that can be safely be iterated concurrently by multiple threads is `ConcurrentIter`.
 //!
 //! Further, there are two traits which define types that can provide a `ConcurrentIter`.
-//! * A [`ConcurrentIterable`] type implements the **`con_iter(&self)`** method which returns a concurrent iterator without consuming the type itself.
-//! * On the other hand, types implementing [`IntoConcurrentIter`] trait has the **`into_con_iter(self)`** method which consumes and converts the type into a concurrent iterator. Additionally there exists [`IterIntoConcurrentIter`] trait which is functionally identical to `IntoConcurrentIter` and only implemented by regular iterators, separated only to allow for special implementations for vectors and arrays.
+//! * A `ConcurrentIterable` type implements the **`con_iter(&self)`** method which returns a concurrent iterator without consuming the type itself.
+//! * On the other hand, types implementing `IntoConcurrentIter` trait has the **`into_con_iter(self)`** method which consumes and converts the type into a concurrent iterator. Additionally there exists `IterIntoConcurrentIter` trait which is functionally identical to `IntoConcurrentIter` and only implemented by regular iterators, separated only to allow for special implementations for vectors and arrays.
 //!
 //! The following table summarizes the implementations of the standard types in this crate.
 //!
-//! | Type | ConcurrentIterable <br/> `con_iter` element type | IntoConcurrentIter <br/> `into_con_iter` element type |
-//! |---|---|---|
-//! | `&'a [T]` | `&'a T` | `&'a T` |
-//! | `Range<Idx>` | `Idx` | `Idx` |
-//! | `Vec<T>` | `&T` | `T` |
-//! | `[T; N]` | `&T` | `T` |
-//! | `Iter: Iterator<Item = T>` | - | `T` |
+//! | Type | ConcurrentIterable <br/> `con_iter()` element type | IntoConcurrentIter <br/> `into_con_iter()` element type | Cloned <br/> `con_iter().cloned()` |
+//! |---|---|---|---|
+//! | `&'a [T]` | `&'a T` | `&'a T` | `T` |
+//! | `Range<Idx>` | `Idx` | `Idx` | |
+//! | `Vec<T>` | `&T` | `T` | |
+//! | `[T; N]` | `&T` | `T` | |
+//! | `Iter: Iterator<Item = T>` | - | `T` | |
 //!
 //!
 //! ## License

--- a/tests/atomic_counter.rs
+++ b/tests/atomic_counter.rs
@@ -1,0 +1,33 @@
+use orx_concurrent_iter::*;
+
+#[test]
+fn new() {
+    let counter = AtomicCounter::new();
+    assert_eq!(counter.current(), 0);
+
+    let counter = AtomicCounter::default();
+    assert_eq!(counter.current(), 0);
+
+    let counter = counter.clone();
+    assert_eq!(counter.current(), 0);
+}
+
+#[test]
+fn fetch_and_add_increment() {
+    let counter = AtomicCounter::new();
+
+    let prior = counter.fetch_and_add(1);
+    assert_eq!(prior, 0);
+    assert_eq!(counter.current(), 1);
+
+    let prior = counter.fetch_and_add(4);
+    assert_eq!(prior, 1);
+    assert_eq!(counter.current(), 5);
+
+    let prior = counter.fetch_and_increment();
+    assert_eq!(prior, 5);
+    assert_eq!(counter.current(), 6);
+
+    let counter = counter.clone();
+    assert_eq!(counter.current(), 6);
+}

--- a/tests/cloned_slice.rs
+++ b/tests/cloned_slice.rs
@@ -1,0 +1,25 @@
+use orx_concurrent_iter::*;
+
+#[test]
+fn cloned_slice() {
+    let values = ['a', 'b', 'c'].map(String::from);
+    let slice = values.as_slice();
+
+    let con_iter = slice.con_iter().cloned();
+    assert_eq!(con_iter.next(), Some("a".to_string()));
+    assert_eq!(con_iter.next(), Some("b".to_string()));
+    assert_eq!(con_iter.next(), Some("c".to_string()));
+    assert_eq!(con_iter.next(), None);
+
+    let con_iter = slice.into_con_iter().cloned();
+    assert_eq!(con_iter.next(), Some("a".to_string()));
+    assert_eq!(con_iter.next(), Some("b".to_string()));
+    assert_eq!(con_iter.next(), Some("c".to_string()));
+    assert_eq!(con_iter.next(), None);
+
+    let con_iter = slice.into_exact_con_iter().cloned();
+    assert_eq!(con_iter.next(), Some("a".to_string()));
+    assert_eq!(con_iter.next(), Some("b".to_string()));
+    assert_eq!(con_iter.next(), Some("c".to_string()));
+    assert_eq!(con_iter.next(), None);
+}


### PR DESCRIPTION
* `ClonedConIterOfSlice` is defined for `T: Clone`. Opposed to `ConIterOfSlice`, this iterator yields cloned values of `T`.
* `ClonedConIterOfSlice` can be created by the `ConIterOfSlice::cloned` method.
* Test coverage increased.