### PR TITLE
concurrency model of `ConIterOfIter` is revised

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-iter"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A thread-safe, ergonomic and lightweight concurrent iterator trait and efficient implementations."

--- a/src/iter/con_iter.rs
+++ b/src/iter/con_iter.rs
@@ -507,6 +507,9 @@ pub trait ConcurrentIter: Send + Sync {
     fn fold<B, Fold>(&self, chunk_size: usize, neutral: B, fold: Fold) -> B
     where
         Fold: FnMut(B, Self::Item) -> B;
+
+    /// Returns Some of the remaining length of the iterator if it is known; returns None otherwise.
+    fn try_get_len(&self) -> Option<usize>;
 }
 
 /// A concurrent iterator that knows its exact length.

--- a/src/iter/constructors/implementors/iter.rs
+++ b/src/iter/constructors/implementors/iter.rs
@@ -11,4 +11,8 @@ where
     fn into_con_iter(self) -> Self::ConIter {
         Self::ConIter::new(self)
     }
+
+    fn try_get_exact_len(&self) -> Option<usize> {
+        None
+    }
 }

--- a/src/iter/constructors/into_con_iter.rs
+++ b/src/iter/constructors/into_con_iter.rs
@@ -25,4 +25,7 @@ pub trait IterIntoConcurrentIter {
 
     /// Consumes this type and converts it into a concurrent iterator.
     fn into_con_iter(self) -> Self::ConIter;
+
+    /// Returns Some of the exact initial length of the iterator to be created if it is known; returns None otherwise.
+    fn try_get_exact_len(&self) -> Option<usize>;
 }

--- a/src/iter/implementors/array.rs
+++ b/src/iter/implementors/array.rs
@@ -140,6 +140,11 @@ impl<const N: usize, T: Send + Sync + Default> ConcurrentIter for ConIterOfArray
     {
         <Self as AtomicIter<_>>::fold(self, chunk_size, neutral, fold)
     }
+
+    #[inline(always)]
+    fn try_get_len(&self) -> Option<usize> {
+        Some(<Self as ExactSizeConcurrentIter>::len(self))
+    }
 }
 
 impl<const N: usize, T: Send + Sync + Default> ExactSizeConcurrentIter for ConIterOfArray<N, T> {

--- a/src/iter/implementors/cloned/slice.rs
+++ b/src/iter/implementors/cloned/slice.rs
@@ -143,6 +143,11 @@ impl<'a, T: Send + Sync + Clone> ConcurrentIter for ClonedConIterOfSlice<'a, T> 
     {
         <Self as AtomicIter<_>>::fold(self, chunk_size, neutral, fold)
     }
+
+    #[inline(always)]
+    fn try_get_len(&self) -> Option<usize> {
+        Some(<Self as ExactSizeConcurrentIter>::len(self))
+    }
 }
 
 impl<'a, T: Send + Sync + Clone> ExactSizeConcurrentIter for ClonedConIterOfSlice<'a, T> {

--- a/src/iter/implementors/range.rs
+++ b/src/iter/implementors/range.rs
@@ -220,6 +220,11 @@ where
     {
         <Self as AtomicIter<_>>::fold(self, chunk_size, neutral, fold)
     }
+
+    #[inline(always)]
+    fn try_get_len(&self) -> Option<usize> {
+        Some(<Self as ExactSizeConcurrentIter>::len(self))
+    }
 }
 
 impl<Idx> ExactSizeConcurrentIter for ConIterOfRange<Idx>

--- a/src/iter/implementors/slice.rs
+++ b/src/iter/implementors/slice.rs
@@ -25,17 +25,17 @@ impl<'a, T: Send + Sync> ConIterOfSlice<'a, T> {
         }
     }
 
-    /// Returns a reference to the underlying slice.
-    pub fn as_slice(&self) -> &'a [T] {
-        self.slice
-    }
-
     /// A concurrent iterator over a slice yielding references to clones of the elements.
     pub fn cloned(self) -> ClonedConIterOfSlice<'a, T>
     where
         T: Clone,
     {
         self.into()
+    }
+
+    /// Returns a reference to the underlying slice.
+    pub(crate) fn as_slice(&self) -> &'a [T] {
+        self.slice
     }
 }
 
@@ -147,6 +147,11 @@ impl<'a, T: Send + Sync> ConcurrentIter for ConIterOfSlice<'a, T> {
         Fold: FnMut(B, Self::Item) -> B,
     {
         <Self as AtomicIter<_>>::fold(self, chunk_size, neutral, fold)
+    }
+
+    #[inline(always)]
+    fn try_get_len(&self) -> Option<usize> {
+        Some(<Self as ExactSizeConcurrentIter>::len(self))
     }
 }
 

--- a/src/iter/implementors/vec.rs
+++ b/src/iter/implementors/vec.rs
@@ -139,6 +139,11 @@ impl<T: Send + Sync + Default> ConcurrentIter for ConIterOfVec<T> {
     {
         <Self as AtomicIter<_>>::fold(self, chunk_size, neutral, fold)
     }
+
+    #[inline(always)]
+    fn try_get_len(&self) -> Option<usize> {
+        Some(<Self as ExactSizeConcurrentIter>::len(self))
+    }
 }
 
 impl<T: Send + Sync + Default> ExactSizeConcurrentIter for ConIterOfVec<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,6 +348,7 @@ pub use iter::con_iter::{ConcurrentIter, ExactSizeConcurrentIter};
 pub use iter::constructors::con_iterable::ConcurrentIterable;
 pub use iter::constructors::into_con_iter::{IntoConcurrentIter, IterIntoConcurrentIter};
 pub use iter::constructors::into_exact_con_iter::IntoExactSizeConcurrentIter;
+pub use iter::implementors::cloned::slice::ClonedConIterOfSlice;
 pub use iter::implementors::{
     array::ConIterOfArray, iter::ConIterOfIter, range::ConIterOfRange, slice::ConIterOfSlice,
     vec::ConIterOfVec,

--- a/src/next.rs
+++ b/src/next.rs
@@ -23,22 +23,30 @@ pub trait NextChunk<T> {
 
 /// A `NextChunk` implementation with a begin index and any iterator, not necessarily with a known length.
 #[derive(Debug)]
-pub struct NextMany<T, Iter>
+pub struct NextMany<T, IntoIter>
 where
-    Iter: Iterator<Item = T>,
+    IntoIter: IntoIterator<Item = T>,
+    IntoIter::IntoIter: ExactSizeIterator<Item = T>,
 {
     pub(crate) begin_idx: usize,
-    pub(crate) values: Iter,
+    pub(crate) values: IntoIter,
 }
 
-impl<T, Iter: Iterator<Item = T>> NextChunk<T> for NextMany<T, Iter> {
+impl<T, Iter, IntoIter> NextChunk<T> for NextMany<T, IntoIter>
+where
+    Iter: Iterator<Item = T>,
+    IntoIter: IntoIterator<Item = T, IntoIter = Iter>,
+    IntoIter::IntoIter: ExactSizeIterator<Item = T>,
+{
     type ChunkIter = Iter;
 
+    /// Type of the iterator yielding elements of the chunk.
     #[inline(always)]
     fn values(self) -> Self::ChunkIter {
-        self.values
+        self.values.into_iter()
     }
 
+    /// The index of the first element to be yielded by the `values` iterator.
     #[inline(always)]
     fn begin_idx(&self) -> usize {
         self.begin_idx

--- a/tests/con_iter.rs
+++ b/tests/con_iter.rs
@@ -228,6 +228,7 @@ fn con_iter_iter(len: usize, num_threads: usize, batch: usize) {
     concurrent_enumerate_for_each_sum(num_threads, batch, clone.iter().into_con_iter(), sum, len);
 }
 
+
 #[test_matrix(
     [1, 2, 8],
     [1, 2, 4, 5, 8, 64, 71, 1024, 1025]

--- a/tests/exact_con_iter.rs
+++ b/tests/exact_con_iter.rs
@@ -120,7 +120,6 @@ where
                     let len = x.exact_len();
                     assert!(len > 0);
                     for (i, value) in x.values().enumerate() {
-                        dbg!(begin_idx, len, i, &value);
                         assert_eq!(begin_idx + i, value + 0);
                     }
                 }

--- a/tests/from_array.rs
+++ b/tests/from_array.rs
@@ -38,3 +38,28 @@ fn exact_len() {
     let values = ['a', 'b', 'c'];
     assert_eq!(3, values.exact_len())
 }
+
+#[test]
+fn len() {
+    let values = ['a', 'b', 'c', 'd'];
+
+    let iter = values.into_con_iter();
+    assert_eq!(iter.len(), 4);
+    assert_eq!(iter.try_get_len(), Some(4));
+
+    _ = iter.next();
+    assert_eq!(iter.len(), 3);
+    assert_eq!(iter.try_get_len(), Some(3));
+
+    _ = iter.next_chunk(2);
+    assert_eq!(iter.len(), 1);
+    assert_eq!(iter.try_get_len(), Some(1));
+
+    _ = iter.next();
+    assert_eq!(iter.len(), 0);
+    assert_eq!(iter.try_get_len(), Some(0));
+
+    _ = iter.next();
+    assert_eq!(iter.len(), 0);
+    assert_eq!(iter.try_get_len(), Some(0));
+}

--- a/tests/from_iter.rs
+++ b/tests/from_iter.rs
@@ -29,3 +29,29 @@ fn con_iter() {
     assert_eq!(con_iter.next(), Some(String::from('c')));
     assert_eq!(con_iter.next(), None);
 }
+
+#[test]
+fn len() {
+    let values = ['a', 'b', 'c', 'd'];
+    let iter = values.iter();
+
+    assert_eq!(iter.try_get_exact_len(), None);
+
+    let con_iter = iter.into_con_iter();
+    assert_eq!(con_iter.try_get_len(), None);
+
+    _ = con_iter.next();
+    assert_eq!(con_iter.try_get_len(), None);
+
+    _ = con_iter.next_chunk(2);
+    assert_eq!(con_iter.try_get_len(), None);
+
+    _ = con_iter.next_chunk(2);
+    assert_eq!(con_iter.try_get_len(), None);
+
+    _ = con_iter.next();
+    assert_eq!(con_iter.try_get_len(), None);
+
+    _ = con_iter.next();
+    assert_eq!(con_iter.try_get_len(), None);
+}

--- a/tests/from_range.rs
+++ b/tests/from_range.rs
@@ -1,6 +1,6 @@
 use orx_concurrent_iter::{
-    ConIterOfIter, ConIterOfRange, ConcurrentIter, ConcurrentIterable, IntoConcurrentIter,
-    IntoExactSizeConcurrentIter,
+    ConIterOfIter, ConIterOfRange, ConcurrentIter, ConcurrentIterable, ExactSizeConcurrentIter,
+    IntoConcurrentIter, IntoExactSizeConcurrentIter,
 };
 
 #[test]
@@ -42,4 +42,29 @@ fn into_con_iter() {
 fn exact_len() {
     let values = 42..45;
     assert_eq!(3, values.exact_len());
+}
+
+#[test]
+fn len() {
+    let values = 42..46;
+
+    let iter = values.con_iter();
+    assert_eq!(iter.len(), 4);
+    assert_eq!(iter.try_get_len(), Some(4));
+
+    _ = iter.next();
+    assert_eq!(iter.len(), 3);
+    assert_eq!(iter.try_get_len(), Some(3));
+
+    _ = iter.next_chunk(2);
+    assert_eq!(iter.len(), 1);
+    assert_eq!(iter.try_get_len(), Some(1));
+
+    _ = iter.next();
+    assert_eq!(iter.len(), 0);
+    assert_eq!(iter.try_get_len(), Some(0));
+
+    _ = iter.next();
+    assert_eq!(iter.len(), 0);
+    assert_eq!(iter.try_get_len(), Some(0));
 }

--- a/tests/from_slice.rs
+++ b/tests/from_slice.rs
@@ -30,3 +30,29 @@ fn exact_len() {
     let slice = values.as_slice();
     assert_eq!(3, slice.exact_len())
 }
+
+#[test]
+fn len() {
+    let values = vec!['a', 'b', 'c', 'd'];
+    let slice = values.as_slice();
+
+    let iter = slice.con_iter();
+    assert_eq!(iter.len(), 4);
+    assert_eq!(iter.try_get_len(), Some(4));
+
+    _ = iter.next();
+    assert_eq!(iter.len(), 3);
+    assert_eq!(iter.try_get_len(), Some(3));
+
+    _ = iter.next_chunk(2);
+    assert_eq!(iter.len(), 1);
+    assert_eq!(iter.try_get_len(), Some(1));
+
+    _ = iter.next();
+    assert_eq!(iter.len(), 0);
+    assert_eq!(iter.try_get_len(), Some(0));
+
+    _ = iter.next();
+    assert_eq!(iter.len(), 0);
+    assert_eq!(iter.try_get_len(), Some(0));
+}

--- a/tests/from_vec.rs
+++ b/tests/from_vec.rs
@@ -38,3 +38,28 @@ fn exact_len() {
     let values = vec!['a', 'b', 'c'];
     assert_eq!(3, values.exact_len())
 }
+
+#[test]
+fn len() {
+    let values = vec!['a', 'b', 'c', 'd'];
+
+    let iter = values.into_con_iter();
+    assert_eq!(iter.len(), 4);
+    assert_eq!(iter.try_get_len(), Some(4));
+
+    _ = iter.next();
+    assert_eq!(iter.len(), 3);
+    assert_eq!(iter.try_get_len(), Some(3));
+
+    _ = iter.next_chunk(2);
+    assert_eq!(iter.len(), 1);
+    assert_eq!(iter.try_get_len(), Some(1));
+
+    _ = iter.next();
+    assert_eq!(iter.len(), 0);
+    assert_eq!(iter.try_get_len(), Some(0));
+
+    _ = iter.next();
+    assert_eq!(iter.len(), 0);
+    assert_eq!(iter.try_get_len(), Some(0));
+}

--- a/tests/slice.rs
+++ b/tests/slice.rs
@@ -14,8 +14,10 @@ fn new() {
     let slice = values.as_slice();
 
     let con_iter = ConIterOfSlice::new(slice);
-    let vec = con_iter.as_slice().to_vec();
-    assert_eq!(slice, &vec);
+    assert_eq!(con_iter.next(), Some(&'a'));
+    assert_eq!(con_iter.next(), Some(&'b'));
+    assert_eq!(con_iter.next(), Some(&'c'));
+    assert_eq!(con_iter.next(), None);
 }
 
 #[test]
@@ -23,9 +25,11 @@ fn from() {
     let values = ['a', 'b', 'c'];
     let slice = values.as_slice();
 
-    let con_iter: ConIterOfSlice<_> = slice.into();
-    let vec = con_iter.as_slice().to_vec();
-    assert_eq!(slice, &vec);
+    let con_iter = ConIterOfSlice::new(slice);
+    assert_eq!(con_iter.next(), Some(&'a'));
+    assert_eq!(con_iter.next(), Some(&'b'));
+    assert_eq!(con_iter.next(), Some(&'c'));
+    assert_eq!(con_iter.next(), None);
 }
 
 #[test]
@@ -50,12 +54,12 @@ fn debug() {
 fn as_slice() {
     let values = ['a', 'b', 'c'];
     let slice = values.as_slice();
+    let vec = slice.to_vec();
 
     let con_iter: ConIterOfSlice<_> = slice.into();
 
     assert_eq!(con_iter.next(), Some(&'a'));
 
-    let vec = con_iter.as_slice().to_vec();
     assert_eq!(slice, &vec);
 }
 


### PR DESCRIPTION
* `try_get_len` method is added to `ConIter`.
* Concurrency model of `ConIterOfIter` is revised. The focus is turned on pulling elements faster trying to increment the atomic counter for reserved elements as quickly as possible.
* `fetch_n` method of `ConIterOfIter` is made eager in order to prevent the other threads waiting for the fetched values to be iterated over. However, this requires returning a vec, i.e., allocation. This could be a topic to be revisited, could we use a buffer here instead?
* Test coverage improved.