### PR TITLE
buffered chunks iterator is implemented

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-iter"
-version = "1.8.0"
+version = "1.9.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A thread-safe, ergonomic and lightweight concurrent iterator trait and efficient implementations."

--- a/README.md
+++ b/README.md
@@ -273,8 +273,8 @@ let characters = &inputs.con_iter();
 let [first, second] = std::thread::scope(|s| {
     let first = s.spawn(move || {
         let mut chars: Vec<char> = vec![];
-        while let Some(chunk) = characters.next_exact_chunk(3) {
-            chars.extend(chunk.values().copied());
+        while let Some(chunk) = characters.next_chunk(3) {
+            chars.extend(chunk.values.copied());
             lag(100);
         }
         chars
@@ -283,8 +283,8 @@ let [first, second] = std::thread::scope(|s| {
     let second = s.spawn(move || {
         lag(50);
         let mut chars: Vec<char> = vec![];
-        while let Some(chunk) = characters.next_exact_chunk(3) {
-            chars.extend(chunk.values().copied());
+        while let Some(chunk) = characters.next_chunk(3) {
+            chars.extend(chunk.values.copied());
             lag(100);
         }
         chars

--- a/src/iter/atomic_iter.rs
+++ b/src/iter/atomic_iter.rs
@@ -1,5 +1,5 @@
 use super::atomic_counter::AtomicCounter;
-use crate::{next::Next, NextChunk, NextManyExact};
+use crate::next::{Next, NextChunk};
 
 /// Trait defining a set of concurrent iterators which internally uses an atomic counter of elements to be yielded.
 ///
@@ -7,6 +7,12 @@ use crate::{next::Next, NextChunk, NextManyExact};
 pub trait AtomicIter<T: Send + Sync>: Send + Sync {
     /// Returns a reference to the underlying advanced item counter.
     fn counter(&self) -> &AtomicCounter;
+
+    /// Progresses the atomic counter by `number_to_fetch` elements and returns the beginning index of the elements to be fetched.
+    /// Returns None if the iterator is terminated and there are no more elements to be fetched.
+    ///
+    /// Note that this method must only return when the calling thread is allowed to fetch elements.
+    fn progress_and_get_begin_idx(&self, number_to_fetch: usize) -> Option<usize>;
 
     /// Returns the `item_idx`-th item that the iterator yields; returns None if the iterator completes before.
     fn get(&self, item_idx: usize) -> Option<T>;
@@ -20,112 +26,11 @@ pub trait AtomicIter<T: Send + Sync>: Send + Sync {
 
     /// Returns an iterator of the next `n` **consecutive items** that the iterator yields.
     /// It might return an iterator of less or no items if the iteration does not have sufficient elements left.
-    fn fetch_n(&self, n: usize) -> impl NextChunk<T>;
-
-    /// Applies the function `f` to each element of the iterator concurrently.
-    ///
-    /// Note that this method might be called on the same iterator at the same time from different threads.
-    /// The iterator guarantees that the function is applied to each element exactly once.
-    ///
-    /// Calling thread will process one input at a time ([`AtomicIter::fetch_one`]) when `n` is set to 1.
-    /// Alternatively, each thread might process `n` consecutive elements at each iteration ([`AtomicIter::fetch_n`]).
-    fn for_each_n<F: FnMut(T)>(&self, n: usize, f: F);
-
-    /// Applies the function `f` to each element and its corresponding index of the iterator concurrently.
-    /// It may be considered as the concurrent counterpart of the chain of `enumerate` and `for_each_n` calls.
-    ///
-    /// Note that this method might be called on the same iterator at the same time from different threads.
-    /// The iterator guarantees that the function is applied to each element exactly once.
-    ///
-    /// Calling thread will process one input at a time ([`AtomicIter::fetch_one`]) when `n` is set to 1.
-    /// Alternatively, each thread might process `n` consecutive elements at each iteration ([`AtomicIter::fetch_n`]).
-    fn enumerate_for_each_n<F: FnMut(usize, T)>(&self, n: usize, f: F);
-
-    /// Folds the elements of the iterator pulled concurrently using `fold` function.
-    ///
-    /// Note that this method might be called on the same iterator at the same time from different threads.
-    /// Each thread will start its concurrent fold operation with the `neutral` value.
-    /// This value is then transformed into the result by applying the `fold` on it together with the pulled elements.
-    ///
-    /// Therefore, each thread will end up at a different partial result.
-    /// Further, each thread's partial result might be different in every execution.
-    /// However, once `fold` is applied starting again from `neutral` using the thread results will lead to the deterministic result which would have been obtained in sequential operation.
-    /// This establishes a very ergonomic parallel fold implementation.
-    ///
-    /// # Examples
-    ///
-    /// Notice that the initial value is called `neutral` as in **monoids**, rather than init or initial.
-    /// This is to highlight that each thread will start its separate execution from this value.
-    ///
-    /// ### Good Example with a Neutral Element
-    ///
-    /// Integer addition and number zero are good examples for `neutral` and `fold`, respectively.
-    /// Assume our iterator will yield 4 values: [3, 4, 1, 9].
-    /// We want to sum these values using two threads.
-    /// We can achieve parallelism very conveniently using `fold` as follows.
-    ///
-    /// ```rust
-    /// use orx_concurrent_iter::*;
-    ///
-    /// let num_threads = 2;
-    ///
-    /// let numbers = vec![3, 4, 1, 9];
-    /// let slice = numbers.as_slice();
-    /// let iter = &slice.con_iter();
-    ///
-    /// let neutral = 0; // neutral for i32 & add
-    ///
-    /// let sum = std::thread::scope(|s| {
-    ///     (0..num_threads)
-    ///         .map(|_| s.spawn(move || iter.fold(1, neutral, |x, y| x + y))) // parallel fold
-    ///         .map(|x| x.join().unwrap())
-    ///         .fold(neutral, |x, y| x + y) // sequential fold
-    /// });
-    ///
-    /// assert_eq!(sum, 17);
-    /// ```
-    ///
-    /// Note that this code can execute in one of many possible ways.
-    /// Let's say our two threads are called tA and tB.
-    /// * tA might pull and sum all four of the numbers; hence, returns 17. tB cannot pull any element and just returns the neutral element. Sequential fold will add 17 and 0, and return 17.
-    /// * tA might pull only the third element; hence, returns 0+1 = 1. tB pulls the other 3 elements and returns 0+3+4+9 = 16. Final fold will then return 0+1+16 = 17.
-    /// * and so on, so forth.
-    ///
-    /// `ConcurrentIter` guarantees that each element is visited and computed exactly once.
-    /// Therefore, the parallel computation will always be correct provided that we provide a neutral element such that:
-    ///
-    /// ```rust ignore
-    /// assert_eq!(fold(neutral, element), element);
-    /// ```
-    ///
-    /// Other trivial examples are:
-    /// * `1` & multiplication
-    /// * empty string/list & string/list concat
-    /// * `true` & logical, etc.
-    ///
-    /// ## Wrong Example with a Non-Neutral Element
-    ///
-    /// In a sequential fold operation, once can start the summation above with an initial value of 100.
-    /// Then, the resulting value would deterministically be 117.
-    ///
-    /// However, if we pass 100 as the neutral element to the concurrent fold above, we would receive 217 (additional 100 for each thread).
-    /// Notice that the result depends on the number of threads used in computation.
-    /// This is incorrect.
-    ///
-    /// In either case, it is a good practice to leave 100 out of the fold operation.
-    /// Ideally, we would pass 0 as the initial and neutral element, and add 100 to the result of the fold operation.
-    fn fold<B, Fold: FnMut(B, T) -> B>(&self, chunk_size: usize, neutral: B, fold: Fold) -> B;
+    fn fetch_n(&self, n: usize) -> Option<NextChunk<T, impl ExactSizeIterator<Item = T>>>;
 }
 
 /// An atomic counter based iterator with exactly known initial length.
 pub trait AtomicIterWithInitialLen<T: Send + Sync>: AtomicIter<T> {
     /// Returns the initial length of the atomic iterator.
     fn initial_len(&self) -> usize;
-
-    /// Returns an iterator of the next `n` **consecutive items** that the iterator together with an exact size iterator.
-    /// It might return an iterator of less or no items if the iteration does not have sufficient elements left.
-    fn fetch_n_with_exact_len(
-        &self,
-        n: usize,
-    ) -> NextManyExact<T, impl ExactSizeIterator<Item = T>>;
 }

--- a/src/iter/buffered/array.rs
+++ b/src/iter/buffered/array.rs
@@ -1,0 +1,37 @@
+use super::buffered_chunk::BufferedChunk;
+use crate::ConIterOfArray;
+
+pub struct BufferedArray<const N: usize> {
+    chunk_size: usize,
+}
+
+impl<const N: usize> BufferedArray<N> {
+    pub fn new(chunk_size: usize) -> Self {
+        Self { chunk_size }
+    }
+}
+
+impl<const N: usize, T> BufferedChunk<T> for BufferedArray<N>
+where
+    T: Send + Sync + Default,
+{
+    type ConIter = ConIterOfArray<N, T>;
+
+    fn chunk_size(&self) -> usize {
+        self.chunk_size
+    }
+
+    fn pull(
+        &mut self,
+        iter: &Self::ConIter,
+        begin_idx: usize,
+    ) -> Option<impl ExactSizeIterator<Item = T>> {
+        let array = unsafe { iter.mut_array() };
+        let end_idx = (begin_idx + self.chunk_size)
+            .min(array.len())
+            .max(begin_idx);
+        let idx_range = begin_idx..end_idx;
+        let values = idx_range.map(|i| std::mem::take(&mut array[i]));
+        Some(values)
+    }
+}

--- a/src/iter/buffered/buffered_chunk.rs
+++ b/src/iter/buffered/buffered_chunk.rs
@@ -1,0 +1,13 @@
+use crate::iter::atomic_iter::AtomicIter;
+
+pub trait BufferedChunk<T: Send + Sync> {
+    type ConIter: AtomicIter<T>;
+
+    fn chunk_size(&self) -> usize;
+
+    fn pull(
+        &mut self,
+        iter: &Self::ConIter,
+        begin_idx: usize,
+    ) -> Option<impl ExactSizeIterator<Item = T>>;
+}

--- a/src/iter/buffered/buffered_iter.rs
+++ b/src/iter/buffered/buffered_iter.rs
@@ -1,0 +1,38 @@
+use super::buffered_chunk::BufferedChunk;
+use crate::{iter::atomic_iter::AtomicIter, NextChunk};
+use std::marker::PhantomData;
+
+pub struct BufferedIter<'a, T, B>
+where
+    T: Send + Sync,
+    B: BufferedChunk<T>,
+{
+    buffered_iter: B,
+    atomic_iter: &'a B::ConIter,
+    phantom: PhantomData<T>,
+}
+
+impl<'a, T, B> BufferedIter<'a, T, B>
+where
+    T: Send + Sync,
+    B: BufferedChunk<T>,
+{
+    pub(crate) fn new(buffered_iter: B, atomic_iter: &'a B::ConIter) -> Self {
+        Self {
+            buffered_iter,
+            atomic_iter,
+            phantom: Default::default(),
+        }
+    }
+
+    #[allow(clippy::unwrap_used, clippy::unwrap_in_result, clippy::question_mark)]
+    pub fn next(&mut self) -> Option<NextChunk<T, impl ExactSizeIterator<Item = T> + '_>> {
+        self.atomic_iter
+            .progress_and_get_begin_idx(self.buffered_iter.chunk_size())
+            .and_then(|begin_idx| {
+                self.buffered_iter
+                    .pull(self.atomic_iter, begin_idx)
+                    .map(|values| NextChunk { begin_idx, values })
+            })
+    }
+}

--- a/src/iter/buffered/iter.rs
+++ b/src/iter/buffered/iter.rs
@@ -1,0 +1,109 @@
+use super::buffered_chunk::BufferedChunk;
+use crate::ConIterOfIter;
+use std::marker::PhantomData;
+
+#[derive(Debug)]
+pub struct BufferIter<T, Iter>
+where
+    T: Send + Sync,
+    Iter: Iterator<Item = T>,
+{
+    values: Vec<Option<T>>,
+    phantom: PhantomData<Iter>,
+}
+
+impl<T, Iter> BufferIter<T, Iter>
+where
+    T: Send + Sync,
+    Iter: Iterator<Item = T>,
+{
+    pub fn new(chunk_size: usize) -> Self {
+        Self {
+            values: (0..chunk_size).map(|_| None).collect(),
+            phantom: Default::default(),
+        }
+    }
+}
+
+impl<T, Iter> BufferedChunk<T> for BufferIter<T, Iter>
+where
+    T: Send + Sync,
+    Iter: Iterator<Item = T>,
+{
+    type ConIter = ConIterOfIter<T, Iter>;
+
+    fn chunk_size(&self) -> usize {
+        self.values.len()
+    }
+
+    fn pull(
+        &mut self,
+        iter: &Self::ConIter,
+        begin_idx: usize,
+    ) -> Option<impl ExactSizeIterator<Item = T>> {
+        let core_iter = unsafe { iter.mut_iter() };
+
+        let mut i = 0;
+        loop {
+            debug_assert!(self.values[i].is_none());
+            let next = core_iter.next();
+            match next {
+                Some(x) => self.values[i] = Some(x),
+                None => break,
+            }
+
+            i += 1;
+            if i == self.chunk_size() {
+                break;
+            }
+        }
+
+        let older_count = iter.progress_yielded_counter(self.chunk_size());
+        assert_eq!(older_count, begin_idx);
+
+        match i {
+            0 => None,
+            _ => {
+                let iter = BufferedIter {
+                    values: &mut self.values,
+                    initial_len: i,
+                    current_idx: 0,
+                };
+                Some(iter)
+            }
+        }
+    }
+}
+
+// Iterator
+pub struct BufferedIter<'a, T> {
+    values: &'a mut [Option<T>],
+    initial_len: usize,
+    current_idx: usize,
+}
+
+impl<'a, T> Iterator for BufferedIter<'a, T> {
+    type Item = T;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current_idx < self.initial_len {
+            let next = self.values[self.current_idx].take();
+            if next.is_some() {
+                self.current_idx += 1;
+            } else {
+                self.current_idx = self.initial_len;
+            }
+            next
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a, T> ExactSizeIterator for BufferedIter<'a, T> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.initial_len - self.current_idx
+    }
+}

--- a/src/iter/buffered/mod.rs
+++ b/src/iter/buffered/mod.rs
@@ -1,0 +1,11 @@
+pub mod array;
+pub mod buffered_chunk;
+pub mod buffered_iter;
+pub mod iter;
+pub mod range;
+pub mod slice;
+pub mod slice_cloned;
+pub mod vec;
+
+#[cfg(test)]
+mod tests;

--- a/src/iter/buffered/range.rs
+++ b/src/iter/buffered/range.rs
@@ -1,0 +1,54 @@
+use super::buffered_chunk::BufferedChunk;
+use crate::ConIterOfRange;
+use std::{
+    cmp::Ordering,
+    ops::{Add, Sub},
+};
+
+pub struct BufferedRange {
+    chunk_size: usize,
+}
+
+impl BufferedRange {
+    pub fn new(chunk_size: usize) -> Self {
+        Self { chunk_size }
+    }
+}
+
+impl<Idx> BufferedChunk<Idx> for BufferedRange
+where
+    Idx: Send
+        + Sync
+        + Clone
+        + Copy
+        + From<usize>
+        + Into<usize>
+        + Add<Idx, Output = Idx>
+        + Sub<Idx, Output = Idx>
+        + Ord,
+{
+    type ConIter = ConIterOfRange<Idx>;
+
+    fn chunk_size(&self) -> usize {
+        self.chunk_size
+    }
+
+    fn pull(
+        &mut self,
+        iter: &Self::ConIter,
+        begin_idx: usize,
+    ) -> Option<impl ExactSizeIterator<Item = Idx>> {
+        let range = iter.range();
+        let begin_value = range.start + begin_idx.into();
+
+        match begin_value.cmp(&range.end) {
+            Ordering::Less => {
+                let end_value = (begin_value + self.chunk_size.into()).min(range.end);
+                let end_idx: usize = (end_value - range.start).into();
+                let values = (begin_idx..end_idx).map(Idx::from);
+                Some(values)
+            }
+            _ => None,
+        }
+    }
+}

--- a/src/iter/buffered/slice.rs
+++ b/src/iter/buffered/slice.rs
@@ -1,0 +1,42 @@
+use super::buffered_chunk::BufferedChunk;
+use crate::ConIterOfSlice;
+use std::cmp::Ordering;
+
+pub struct BufferedSlice {
+    chunk_size: usize,
+}
+
+impl BufferedSlice {
+    pub fn new(chunk_size: usize) -> Self {
+        Self { chunk_size }
+    }
+}
+
+impl<'a, T> BufferedChunk<&'a T> for BufferedSlice
+where
+    T: Send + Sync,
+{
+    type ConIter = ConIterOfSlice<'a, T>;
+
+    fn chunk_size(&self) -> usize {
+        self.chunk_size
+    }
+
+    fn pull(
+        &mut self,
+        iter: &Self::ConIter,
+        begin_idx: usize,
+    ) -> Option<impl ExactSizeIterator<Item = &'a T>> {
+        let slice = iter.as_slice();
+        match begin_idx.cmp(&slice.len()) {
+            Ordering::Less => {
+                let end_idx = (begin_idx + self.chunk_size)
+                    .min(slice.len())
+                    .max(begin_idx);
+                let values = slice[begin_idx..end_idx].iter();
+                Some(values)
+            }
+            _ => None,
+        }
+    }
+}

--- a/src/iter/buffered/slice_cloned.rs
+++ b/src/iter/buffered/slice_cloned.rs
@@ -1,0 +1,46 @@
+use super::buffered_chunk::BufferedChunk;
+use crate::ClonedConIterOfSlice;
+use std::{cmp::Ordering, marker::PhantomData};
+
+pub struct BufferedSliceCloned<'a> {
+    chunk_size: usize,
+    phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> BufferedSliceCloned<'a> {
+    pub fn new(chunk_size: usize) -> Self {
+        Self {
+            chunk_size,
+            phantom: Default::default(),
+        }
+    }
+}
+
+impl<'a, T> BufferedChunk<T> for BufferedSliceCloned<'a>
+where
+    T: Send + Sync + Clone + 'a,
+{
+    type ConIter = ClonedConIterOfSlice<'a, T>;
+
+    fn chunk_size(&self) -> usize {
+        self.chunk_size
+    }
+
+    fn pull(
+        &mut self,
+        iter: &Self::ConIter,
+        begin_idx: usize,
+    ) -> Option<impl ExactSizeIterator<Item = T>> {
+        let slice = iter.as_slice();
+        match begin_idx.cmp(&slice.len()) {
+            Ordering::Less => {
+                let end_idx = (begin_idx + self.chunk_size)
+                    .min(slice.len())
+                    .max(begin_idx);
+                let values = slice[begin_idx..end_idx].iter().cloned();
+                Some(values)
+            }
+            _ => None,
+        }
+    }
+}

--- a/src/iter/buffered/tests/array.rs
+++ b/src/iter/buffered/tests/array.rs
@@ -1,0 +1,35 @@
+use crate::*;
+use test_case::test_matrix;
+
+#[test_matrix(
+    [2, 16],
+    [1, 64]
+)]
+fn primitive(num_threads: usize, batch: usize) {
+    let mut source = [0i64; 1024];
+    for (i, x) in source.iter_mut().enumerate() {
+        *x = i as i64;
+    }
+    let expected_sum: i64 = source.iter().sum();
+
+    let con_iter = source.into_con_iter();
+    let iter = &con_iter;
+
+    let sum: i64 = std::thread::scope(|s| {
+        let mut handles = vec![];
+        for _ in 0..num_threads {
+            handles.push(s.spawn(move || {
+                let mut sum = 0i64;
+                let mut chunks_iter = iter.buffered_iter(batch);
+                while let Some(next) = chunks_iter.next() {
+                    sum += next.values.sum::<i64>();
+                }
+                sum
+            }));
+        }
+
+        handles.into_iter().map(|x| x.join().expect("-")).sum()
+    });
+
+    assert_eq!(sum, expected_sum);
+}

--- a/src/iter/buffered/tests/iter.rs
+++ b/src/iter/buffered/tests/iter.rs
@@ -1,0 +1,66 @@
+use crate::*;
+use test_case::test_matrix;
+
+#[test_matrix(
+    [32, 1024],
+    [2, 16],
+    [1, 64]
+)]
+fn primitive(len: usize, num_threads: usize, batch: usize) {
+    let vec: Vec<_> = (0..len).map(|x| x as i64).collect();
+    let source = vec.iter().skip(1).take(len - 2);
+    let expected_sum: i64 = source.clone().sum();
+
+    let con_iter = source.into_con_iter();
+    let iter = &con_iter;
+
+    let sum: i64 = std::thread::scope(|s| {
+        let mut handles = vec![];
+        for _ in 0..num_threads {
+            handles.push(s.spawn(move || {
+                let mut sum = 0i64;
+                let mut chunks_iter = iter.buffered_iter(batch);
+                while let Some(next) = chunks_iter.next() {
+                    sum += next.values.sum::<i64>();
+                }
+                sum
+            }));
+        }
+
+        handles.into_iter().map(|x| x.join().expect("-")).sum()
+    });
+
+    assert_eq!(sum, expected_sum);
+}
+
+#[test_matrix(
+    [32, 1024],
+    [2, 16],
+    [1, 64]
+)]
+fn heap(len: usize, num_threads: usize, batch: usize) {
+    let vec: Vec<_> = (0..len).map(|x| x.to_string()).collect();
+    let source = vec.iter().skip(1).take(len - 2);
+    let expected_sum: usize = source.clone().map(|x| x.len()).sum();
+
+    let con_iter = source.into_con_iter();
+    let iter = &con_iter;
+
+    let sum: usize = std::thread::scope(|s| {
+        let mut handles = vec![];
+        for _ in 0..num_threads {
+            handles.push(s.spawn(move || {
+                let mut sum = 0usize;
+                let mut chunks_iter = iter.buffered_iter(batch);
+                while let Some(next) = chunks_iter.next() {
+                    sum += next.values.map(|x| x.len()).sum::<usize>();
+                }
+                sum
+            }));
+        }
+
+        handles.into_iter().map(|x| x.join().expect("-")).sum()
+    });
+
+    assert_eq!(sum, expected_sum);
+}

--- a/src/iter/buffered/tests/mod.rs
+++ b/src/iter/buffered/tests/mod.rs
@@ -1,0 +1,6 @@
+mod array;
+mod iter;
+mod range;
+mod slice;
+mod slice_cloned;
+mod vec;

--- a/src/iter/buffered/tests/range.rs
+++ b/src/iter/buffered/tests/range.rs
@@ -1,0 +1,33 @@
+use crate::{ConcurrentIter, IntoConcurrentIter};
+use test_case::test_matrix;
+
+#[test_matrix(
+    [32, 1024],
+    [2, 16],
+    [1, 64]
+)]
+fn primitive(len: usize, num_threads: usize, batch: usize) {
+    let source = 0..len;
+    let expected_sum: i64 = source.clone().sum::<usize>() as i64;
+
+    let con_iter = source.into_con_iter();
+    let iter = &con_iter;
+
+    let sum: i64 = std::thread::scope(|s| {
+        let mut handles = vec![];
+        for _ in 0..num_threads {
+            handles.push(s.spawn(move || {
+                let mut sum = 0i64;
+                let mut chunks_iter = iter.buffered_iter(batch);
+                while let Some(next) = chunks_iter.next() {
+                    sum += next.values.sum::<usize>() as i64;
+                }
+                sum
+            }));
+        }
+
+        handles.into_iter().map(|x| x.join().expect("-")).sum()
+    });
+
+    assert_eq!(sum, expected_sum);
+}

--- a/src/iter/buffered/tests/slice.rs
+++ b/src/iter/buffered/tests/slice.rs
@@ -1,0 +1,66 @@
+use crate::*;
+use test_case::test_matrix;
+
+#[test_matrix(
+    [32, 1024],
+    [2, 16],
+    [1, 64]
+)]
+fn primitive(len: usize, num_threads: usize, batch: usize) {
+    let vec: Vec<_> = (0..len).map(|x| x as i64).collect();
+    let source = vec.as_slice();
+    let expected_sum: i64 = source.iter().sum();
+
+    let con_iter = source.into_con_iter();
+    let iter = &con_iter;
+
+    let sum: i64 = std::thread::scope(|s| {
+        let mut handles = vec![];
+        for _ in 0..num_threads {
+            handles.push(s.spawn(move || {
+                let mut sum = 0i64;
+                let mut chunks_iter = iter.buffered_iter(batch);
+                while let Some(next) = chunks_iter.next() {
+                    sum += next.values.sum::<i64>();
+                }
+                sum
+            }));
+        }
+
+        handles.into_iter().map(|x| x.join().expect("-")).sum()
+    });
+
+    assert_eq!(sum, expected_sum);
+}
+
+#[test_matrix(
+    [32, 1024],
+    [2, 16],
+    [1, 64]
+)]
+fn heap(len: usize, num_threads: usize, batch: usize) {
+    let vec: Vec<_> = (0..len).map(|x| x.to_string()).collect();
+    let source = vec.as_slice();
+    let expected_sum: usize = source.iter().map(|x| x.len()).sum();
+
+    let con_iter = source.into_con_iter();
+    let iter = &con_iter;
+
+    let sum: usize = std::thread::scope(|s| {
+        let mut handles = vec![];
+        for _ in 0..num_threads {
+            handles.push(s.spawn(move || {
+                let mut sum = 0usize;
+                let mut chunks_iter = iter.buffered_iter(batch);
+                while let Some(next) = chunks_iter.next() {
+                    sum += next.values.map(|x| x.len()).sum::<usize>();
+                }
+                sum
+            }));
+        }
+
+        handles.into_iter().map(|x| x.join().expect("-")).sum()
+    });
+
+    assert_eq!(sum, expected_sum);
+}

--- a/src/iter/buffered/tests/slice_cloned.rs
+++ b/src/iter/buffered/tests/slice_cloned.rs
@@ -1,0 +1,66 @@
+use crate::*;
+use test_case::test_matrix;
+
+#[test_matrix(
+    [32, 1024],
+    [2, 16],
+    [1, 64]
+)]
+fn primitive(len: usize, num_threads: usize, batch: usize) {
+    let vec: Vec<_> = (0..len).map(|x| x as i64).collect();
+    let source = vec.as_slice();
+    let expected_sum: i64 = source.iter().sum();
+
+    let con_iter = source.into_con_iter().cloned();
+    let iter = &con_iter;
+
+    let sum: i64 = std::thread::scope(|s| {
+        let mut handles = vec![];
+        for _ in 0..num_threads {
+            handles.push(s.spawn(move || {
+                let mut sum = 0i64;
+                let mut chunks_iter = iter.buffered_iter(batch);
+                while let Some(next) = chunks_iter.next() {
+                    sum += next.values.sum::<i64>();
+                }
+                sum
+            }));
+        }
+
+        handles.into_iter().map(|x| x.join().expect("-")).sum()
+    });
+
+    assert_eq!(sum, expected_sum);
+}
+
+#[test_matrix(
+    [32, 1024],
+    [2, 16],
+    [1, 64]
+)]
+fn heap(len: usize, num_threads: usize, batch: usize) {
+    let vec: Vec<_> = (0..len).map(|x| x.to_string()).collect();
+    let source = vec.as_slice();
+    let expected_sum: usize = source.iter().map(|x| x.len()).sum();
+
+    let con_iter = source.into_con_iter().cloned();
+    let iter = &con_iter;
+
+    let sum: usize = std::thread::scope(|s| {
+        let mut handles = vec![];
+        for _ in 0..num_threads {
+            handles.push(s.spawn(move || {
+                let mut sum = 0usize;
+                let mut chunks_iter = iter.buffered_iter(batch);
+                while let Some(next) = chunks_iter.next() {
+                    sum += next.values.map(|x| x.len()).sum::<usize>();
+                }
+                sum
+            }));
+        }
+
+        handles.into_iter().map(|x| x.join().expect("-")).sum()
+    });
+
+    assert_eq!(sum, expected_sum);
+}

--- a/src/iter/buffered/tests/vec.rs
+++ b/src/iter/buffered/tests/vec.rs
@@ -1,0 +1,64 @@
+use crate::*;
+use test_case::test_matrix;
+
+#[test_matrix(
+    [32, 1024],
+    [2, 16],
+    [1, 64]
+)]
+fn primitive(len: usize, num_threads: usize, batch: usize) {
+    let source: Vec<_> = (0..len).map(|x| x as i64).collect();
+    let expected_sum: i64 = source.iter().sum();
+
+    let con_iter = source.into_con_iter();
+    let iter = &con_iter;
+
+    let sum: i64 = std::thread::scope(|s| {
+        let mut handles = vec![];
+        for _ in 0..num_threads {
+            handles.push(s.spawn(move || {
+                let mut sum = 0i64;
+                let mut chunks_iter = iter.buffered_iter(batch);
+                while let Some(next) = chunks_iter.next() {
+                    sum += next.values.sum::<i64>();
+                }
+                sum
+            }));
+        }
+
+        handles.into_iter().map(|x| x.join().expect("-")).sum()
+    });
+
+    assert_eq!(sum, expected_sum);
+}
+
+#[test_matrix(
+    [32, 1024],
+    [2, 16],
+    [1, 64]
+)]
+fn heap(len: usize, num_threads: usize, batch: usize) {
+    let source: Vec<_> = (0..len).map(|x| x.to_string()).collect();
+    let expected_sum: usize = source.iter().map(|x| x.len()).sum();
+
+    let con_iter = source.into_con_iter();
+    let iter = &con_iter;
+
+    let sum: usize = std::thread::scope(|s| {
+        let mut handles = vec![];
+        for _ in 0..num_threads {
+            handles.push(s.spawn(move || {
+                let mut sum = 0usize;
+                let mut chunks_iter = iter.buffered_iter(batch);
+                while let Some(next) = chunks_iter.next() {
+                    sum += next.values.map(|x| x.len()).sum::<usize>();
+                }
+                sum
+            }));
+        }
+
+        handles.into_iter().map(|x| x.join().expect("-")).sum()
+    });
+
+    assert_eq!(sum, expected_sum);
+}

--- a/src/iter/buffered/vec.rs
+++ b/src/iter/buffered/vec.rs
@@ -1,0 +1,35 @@
+use super::buffered_chunk::BufferedChunk;
+use crate::ConIterOfVec;
+
+pub struct BufferedVec {
+    chunk_size: usize,
+}
+
+impl BufferedVec {
+    pub fn new(chunk_size: usize) -> Self {
+        Self { chunk_size }
+    }
+}
+
+impl<T> BufferedChunk<T> for BufferedVec
+where
+    T: Send + Sync + Default,
+{
+    type ConIter = ConIterOfVec<T>;
+
+    fn chunk_size(&self) -> usize {
+        self.chunk_size
+    }
+
+    fn pull(
+        &mut self,
+        iter: &Self::ConIter,
+        begin_idx: usize,
+    ) -> Option<impl ExactSizeIterator<Item = T>> {
+        let vec = unsafe { iter.mut_vec() };
+        let end_idx = (begin_idx + self.chunk_size).min(vec.len()).max(begin_idx);
+        let idx_range = begin_idx..end_idx;
+        let values = idx_range.map(|i| std::mem::take(&mut vec[i]));
+        Some(values)
+    }
+}

--- a/src/iter/default_fns/fold.rs
+++ b/src/iter/default_fns/fold.rs
@@ -1,49 +1,14 @@
-use crate::{ConcurrentIter, ExactSizeConcurrentIter, NextChunk};
+use crate::ConcurrentIter;
 
-// ANY
-pub(crate) fn any_fold<I, F, B>(iter: &I, chunk_size: usize, f: F, initial: B) -> B
+pub(crate) fn fold<I, Fold, B>(iter: &I, chunk_size: usize, fold: Fold, neutral: B) -> B
 where
     I: ConcurrentIter,
-    F: FnMut(B, I::Item) -> B,
+    Fold: FnMut(B, I::Item) -> B,
 {
     assert!(chunk_size > 0, "Chunk size must be positive.");
-    let mut f = f;
+    let mut f = fold;
 
-    let mut result = initial;
-
-    match chunk_size {
-        1 => {
-            while let Some(value) = iter.next() {
-                result = f(result, value);
-            }
-        }
-        _ => loop {
-            let next = iter.next_chunk(chunk_size);
-            let mut has_any = false;
-            for value in next.values() {
-                has_any = true;
-                result = f(result, value);
-            }
-
-            if !has_any {
-                break;
-            }
-        },
-    }
-
-    result
-}
-
-// EXACT
-pub(crate) fn exact_fold<I, F, B>(iter: &I, chunk_size: usize, f: F, initial: B) -> B
-where
-    I: ExactSizeConcurrentIter,
-    F: FnMut(B, I::Item) -> B,
-{
-    assert!(chunk_size > 0, "Chunk size must be positive.");
-    let mut f = f;
-
-    let mut result = initial;
+    let mut result = neutral;
 
     match chunk_size {
         1 => {
@@ -52,8 +17,9 @@ where
             }
         }
         _ => {
-            while let Some(next) = iter.next_exact_chunk(chunk_size) {
-                for value in next.values() {
+            let mut buffered_iter = iter.buffered_iter(chunk_size);
+            while let Some(chunk) = buffered_iter.next() {
+                for value in chunk.values {
                     result = f(result, value);
                 }
             }

--- a/src/iter/default_fns/for_each.rs
+++ b/src/iter/default_fns/for_each.rs
@@ -1,73 +1,12 @@
-use crate::{ConcurrentIter, ExactSizeConcurrentIter, NextChunk};
+use crate::ConcurrentIter;
 
-// ANY
-pub(crate) fn any_for_each<I, F>(iter: &I, chunk_size: usize, f: F)
+pub(crate) fn for_each<I, F>(iter: &I, chunk_size: usize, fun: F)
 where
     I: ConcurrentIter,
     F: FnMut(I::Item),
 {
     assert!(chunk_size > 0, "Chunk size must be positive.");
-    let mut f = f;
-
-    match chunk_size {
-        1 => {
-            while let Some(value) = iter.next() {
-                f(value);
-            }
-        }
-        _ => loop {
-            let next = iter.next_chunk(chunk_size);
-            let mut has_any = false;
-            for value in next.values() {
-                has_any = true;
-                f(value);
-            }
-
-            if !has_any {
-                break;
-            }
-        },
-    }
-}
-
-pub(crate) fn any_for_each_with_ids<I, F>(iter: &I, chunk_size: usize, f: F)
-where
-    I: ConcurrentIter,
-    F: FnMut(usize, I::Item),
-{
-    assert!(chunk_size > 0, "Chunk size must be positive.");
-    let mut f = f;
-
-    match chunk_size {
-        1 => {
-            while let Some(next) = iter.next_id_and_value() {
-                f(next.idx, next.value);
-            }
-        }
-        _ => loop {
-            let next = iter.next_chunk(chunk_size);
-            let begin_idx = next.begin_idx();
-            let mut has_any = false;
-            for (i, value) in next.values().enumerate() {
-                has_any = true;
-                f(begin_idx + i, value);
-            }
-
-            if !has_any {
-                break;
-            }
-        },
-    }
-}
-
-// EXACT
-pub(crate) fn exact_for_each<I, F>(iter: &I, chunk_size: usize, f: F)
-where
-    I: ExactSizeConcurrentIter,
-    F: FnMut(I::Item),
-{
-    assert!(chunk_size > 0, "Chunk size must be positive.");
-    let mut f = f;
+    let mut f = fun;
 
     match chunk_size {
         1 => {
@@ -76,20 +15,21 @@ where
             }
         }
         _ => {
-            while let Some(next) = iter.next_exact_chunk(chunk_size) {
-                next.values().for_each(&mut f);
+            let mut buffered_iter = iter.buffered_iter(chunk_size);
+            while let Some(chunk) = buffered_iter.next() {
+                chunk.values.for_each(&mut f);
             }
         }
     }
 }
 
-pub(crate) fn exact_for_each_with_ids<I, F>(iter: &I, chunk_size: usize, f: F)
+pub(crate) fn for_each_with_ids<I, F>(iter: &I, chunk_size: usize, fun: F)
 where
-    I: ExactSizeConcurrentIter,
+    I: ConcurrentIter,
     F: FnMut(usize, I::Item),
 {
     assert!(chunk_size > 0, "Chunk size must be positive.");
-    let mut f = f;
+    let mut f = fun;
 
     match chunk_size {
         1 => {
@@ -98,9 +38,10 @@ where
             }
         }
         _ => {
-            while let Some(next) = iter.next_exact_chunk(chunk_size) {
-                let begin_idx = next.begin_idx();
-                for (i, value) in next.values().enumerate() {
+            let mut buffered_iter = iter.buffered_iter(chunk_size);
+            while let Some(chunk) = buffered_iter.next() {
+                let begin_idx = chunk.begin_idx;
+                for (i, value) in chunk.values.enumerate() {
                     f(begin_idx + i, value);
                 }
             }

--- a/src/iter/default_fns/tests/fold.rs
+++ b/src/iter/default_fns/tests/fold.rs
@@ -12,7 +12,7 @@ fn any_fold(len: usize, chunk_size: usize) {
 
     let iter = numbers.iter().skip(1).take(len - 1);
     let con_iter = iter.into_con_iter();
-    let sum = default_fns::fold::any_fold(&con_iter, chunk_size, |a, b| a + *b as i64, 0i64);
+    let sum = default_fns::fold::fold(&con_iter, chunk_size, |a, b| a + *b as i64, 0i64);
 
     assert_eq!(sum, expected);
 }
@@ -25,8 +25,7 @@ fn exact_fold(len: usize, chunk_size: usize) {
     let numbers: Vec<_> = (0..len).collect();
     let expected = numbers.iter().sum::<usize>() as i64;
 
-    let sum =
-        default_fns::fold::exact_fold(&numbers.con_iter(), chunk_size, |a, b| a + *b as i64, 0i64);
+    let sum = default_fns::fold::fold(&numbers.con_iter(), chunk_size, |a, b| a + *b as i64, 0i64);
 
     assert_eq!(sum, expected);
 }
@@ -34,16 +33,9 @@ fn exact_fold(len: usize, chunk_size: usize) {
 // panics
 #[test]
 #[should_panic]
-fn panics_any_fold() {
+fn panics_fold_with_zero_chunk() {
     let numbers: Vec<_> = (0..64).collect();
     let iter = numbers.iter().skip(1).take(8);
     let con_iter = iter.into_con_iter();
-    let _ = default_fns::fold::any_fold(&con_iter, 0, |a, b| a + *b as i64, 0i64);
-}
-
-#[test]
-#[should_panic]
-fn panics_exact_fold() {
-    let numbers: Vec<_> = (0..64).collect();
-    let _ = default_fns::fold::exact_fold(&numbers.con_iter(), 0, |a, b| a + *b as i64, 0i64);
+    let _ = default_fns::fold::fold(&con_iter, 0, |a, b| a + *b as i64, 0i64);
 }

--- a/src/iter/default_fns/tests/for_each.rs
+++ b/src/iter/default_fns/tests/for_each.rs
@@ -13,7 +13,7 @@ fn any_for_each(len: usize, chunk_size: usize) {
 
     let iter = numbers.iter().skip(1).take(len - 1);
     let con_iter = iter.into_con_iter();
-    default_fns::for_each::any_for_each(&con_iter, chunk_size, |x| {
+    default_fns::for_each::for_each(&con_iter, chunk_size, |x| {
         sum += x;
     });
 
@@ -31,7 +31,7 @@ fn any_for_each_with_ids(len: usize, chunk_size: usize) {
     let mut indices = 0;
 
     let con_iter = numbers.into_con_iter();
-    default_fns::for_each::any_for_each_with_ids(&con_iter, chunk_size, |i, x| {
+    default_fns::for_each::for_each_with_ids(&con_iter, chunk_size, |i, x| {
         sum += x;
         indices -= i as i64;
     });
@@ -49,7 +49,7 @@ fn exact_for_each(len: usize, chunk_size: usize) {
     let expected: usize = numbers.iter().sum();
     let mut sum = 0;
 
-    default_fns::for_each::exact_for_each(&numbers.con_iter(), chunk_size, |x| {
+    default_fns::for_each::for_each(&numbers.con_iter(), chunk_size, |x| {
         sum += x;
     });
 
@@ -66,7 +66,7 @@ fn exact_for_each_with_ids(len: usize, chunk_size: usize) {
     let mut sum = 0;
     let mut indices = 0;
 
-    default_fns::for_each::exact_for_each_with_ids(&numbers.con_iter(), chunk_size, |i, x| {
+    default_fns::for_each::for_each_with_ids(&numbers.con_iter(), chunk_size, |i, x| {
         sum += x;
         indices -= i as i64;
     });
@@ -83,7 +83,7 @@ fn panics_any_for_each() {
     let mut sum = 0;
     let iter = numbers.iter().skip(1).take(8);
     let con_iter = iter.into_con_iter();
-    default_fns::for_each::any_for_each(&con_iter, 0, |x| {
+    default_fns::for_each::for_each(&con_iter, 0, |x| {
         sum += x;
     });
 }
@@ -95,7 +95,7 @@ fn panics_any_for_each_with_ids() {
     let mut sum = 0;
     let iter = numbers.iter().skip(1).take(8);
     let con_iter = iter.into_con_iter();
-    default_fns::for_each::any_for_each_with_ids(&con_iter, 0, |_i, x| {
+    default_fns::for_each::for_each_with_ids(&con_iter, 0, |_i, x| {
         sum += x;
     });
 }
@@ -105,7 +105,7 @@ fn panics_any_for_each_with_ids() {
 fn panics_exact_for_each() {
     let numbers: Vec<_> = (0..64).collect();
     let mut sum = 0;
-    default_fns::for_each::exact_for_each(&numbers.con_iter(), 0, |x| {
+    default_fns::for_each::for_each(&numbers.con_iter(), 0, |x| {
         sum += x;
     });
 }
@@ -115,7 +115,7 @@ fn panics_exact_for_each() {
 fn panics_exact_for_each_with_ids() {
     let numbers: Vec<_> = (0..64).collect();
     let mut sum = 0;
-    default_fns::for_each::exact_for_each_with_ids(&numbers.con_iter(), 0, |_i, x| {
+    default_fns::for_each::for_each_with_ids(&numbers.con_iter(), 0, |_i, x| {
         sum += x;
     });
 }

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod atomic_counter;
 /// Module defining concurrent iterators based on an atomic counter.
 pub mod atomic_iter;
+mod buffered;
 pub(crate) mod con_iter;
 pub(crate) mod constructors;
 mod default_fns;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,8 +273,8 @@
 //! let [first, second] = std::thread::scope(|s| {
 //!     let first = s.spawn(move || {
 //!         let mut chars: Vec<char> = vec![];
-//!         while let Some(chunk) = characters.next_exact_chunk(3) {
-//!             chars.extend(chunk.values().copied());
+//!         while let Some(chunk) = characters.next_chunk(3) {
+//!             chars.extend(chunk.values.copied());
 //!             lag(100);
 //!         }
 //!         chars
@@ -283,8 +283,8 @@
 //!     let second = s.spawn(move || {
 //!         lag(50);
 //!         let mut chars: Vec<char> = vec![];
-//!         while let Some(chunk) = characters.next_exact_chunk(3) {
-//!             chars.extend(chunk.values().copied());
+//!         while let Some(chunk) = characters.next_chunk(3) {
+//!             chars.extend(chunk.values.copied());
 //!             lag(100);
 //!         }
 //!         chars
@@ -354,4 +354,4 @@ pub use iter::implementors::{
     vec::ConIterOfVec,
 };
 pub use iter::wrappers::{ids_and_values::ConIterIdsAndValues, values::ConIterValues};
-pub use next::{Next, NextChunk, NextMany, NextManyExact};
+pub use next::{Next, NextChunk};

--- a/src/next.rs
+++ b/src/next.rs
@@ -10,81 +10,13 @@ pub struct Next<T> {
 }
 
 /// A trait representing return types of a `next_chunk` call on a concurrent iterator.
-pub trait NextChunk<T> {
-    /// Type of the iterator yielding elements of the chunk.
-    type ChunkIter: Iterator<Item = T>;
-
-    /// Elements in the obtained chunk.
-    fn values(self) -> Self::ChunkIter;
-
-    /// The index of the first element to be yielded by the `values` iterator.
-    fn begin_idx(&self) -> usize;
-}
-
-/// A `NextChunk` implementation with a begin index and any iterator, not necessarily with a known length.
-#[derive(Debug)]
-pub struct NextMany<T, IntoIter>
-where
-    IntoIter: IntoIterator<Item = T>,
-    IntoIter::IntoIter: ExactSizeIterator<Item = T>,
-{
-    pub(crate) begin_idx: usize,
-    pub(crate) values: IntoIter,
-}
-
-impl<T, Iter, IntoIter> NextChunk<T> for NextMany<T, IntoIter>
-where
-    Iter: Iterator<Item = T>,
-    IntoIter: IntoIterator<Item = T, IntoIter = Iter>,
-    IntoIter::IntoIter: ExactSizeIterator<Item = T>,
-{
-    type ChunkIter = Iter;
-
-    /// Type of the iterator yielding elements of the chunk.
-    #[inline(always)]
-    fn values(self) -> Self::ChunkIter {
-        self.values.into_iter()
-    }
-
-    /// The index of the first element to be yielded by the `values` iterator.
-    #[inline(always)]
-    fn begin_idx(&self) -> usize {
-        self.begin_idx
-    }
-}
-
-/// A `NextChunk` implementation with a begin index and an `ExactSizeIterator` iterator with known length.
-#[derive(Debug)]
-pub struct NextManyExact<T, Iter>
+pub struct NextChunk<T, Iter>
 where
     Iter: ExactSizeIterator<Item = T>,
 {
-    pub(crate) begin_idx: usize,
-    pub(crate) values: Iter,
-}
+    /// The index of the first element to be yielded by the `values` iterator.
+    pub begin_idx: usize,
 
-impl<T, Iter: ExactSizeIterator<Item = T>> NextManyExact<T, Iter> {
-    /// Exact length of the chunk which is less than or equal to the requested chunk size.
-    pub fn exact_len(&self) -> usize {
-        self.values.len()
-    }
-
-    /// Returns whether or not the chunk is empty.
-    pub fn is_empty(&self) -> bool {
-        self.values.len() == 0
-    }
-}
-
-impl<T, Iter: ExactSizeIterator<Item = T>> NextChunk<T> for NextManyExact<T, Iter> {
-    type ChunkIter = Iter;
-
-    #[inline(always)]
-    fn values(self) -> Self::ChunkIter {
-        self.values
-    }
-
-    #[inline(always)]
-    fn begin_idx(&self) -> usize {
-        self.begin_idx
-    }
+    /// Elements in the obtained chunk.
+    pub values: Iter,
 }

--- a/tests/atomic.rs
+++ b/tests/atomic.rs
@@ -42,20 +42,14 @@ where
     assert_eq!(0, iter.counter().current());
 
     let mut i = 0;
-    let mut has_more = true;
 
-    while has_more {
-        has_more = false;
-        let next_id_and_chunk = iter.fetch_n(n);
-        let begin_idx = next_id_and_chunk.begin_idx();
-        for (j, value) in next_id_and_chunk.values().enumerate() {
+    while let Some(chunk) = iter.fetch_n(n) {
+        for (j, value) in chunk.values.enumerate() {
             let value = value + 0usize;
-            assert_eq!(value, begin_idx + j);
+            assert_eq!(value, chunk.begin_idx + j);
             assert_eq!(value, i);
 
             i += 1;
-
-            has_more = true;
         }
     }
 }
@@ -89,20 +83,9 @@ where
     assert!(!iter.is_empty());
     assert_eq!(iter.len(), remaining);
 
-    let mut has_more = true;
-    while has_more {
-        has_more = false;
-
-        let next_id_and_chunk = iter.fetch_n(n);
-        if next_id_and_chunk.values().next().is_some() {
-            has_more = true;
-        }
-
-        if n > remaining {
-            remaining = 0;
-        } else {
-            remaining -= n;
-        }
+    while let Some(chunk) = iter.fetch_n(n) {
+        let num_fetched = chunk.values.len();
+        remaining -= num_fetched;
 
         assert_eq!(iter.len(), remaining);
     }

--- a/tests/consume_array.rs
+++ b/tests/consume_array.rs
@@ -17,14 +17,8 @@ fn concurrent_iter(num_threads: usize, batch: usize, array: [i64; 1024]) {
                         sum += next.value;
                     }
                 } else {
-                    let mut more = true;
-                    while more {
-                        more = false;
-                        let next = iter.next_chunk(batch);
-                        for value in next.values() {
-                            sum += value;
-                            more = true;
-                        }
+                    while let Some(chunk) = iter.next_chunk(batch) {
+                        sum += chunk.values.sum::<i64>();
                     }
                 }
                 sum
@@ -38,8 +32,8 @@ fn concurrent_iter(num_threads: usize, batch: usize, array: [i64; 1024]) {
 }
 
 #[test_matrix(
-    [4 ,8, 16],
-    [1, 2, 4, 5, 8, 64, 71, 1024, 1025]
+    [4, 8, 16],
+    [1, 4, 64, 1024]
 )]
 fn consume_array(num_threads: usize, batch: usize) {
     for _ in 0..NUM_RERUNS {

--- a/tests/consume_iter.rs
+++ b/tests/consume_iter.rs
@@ -21,14 +21,8 @@ fn concurrent_iter<I: Iterator<Item = i64>>(
                         sum += next.value;
                     }
                 } else {
-                    let mut more = true;
-                    while more {
-                        more = false;
-                        let next = iter.next_chunk(batch);
-                        for value in next.values() {
-                            sum += value;
-                            more = true;
-                        }
+                    while let Some(chunk) = iter.next_chunk(batch) {
+                        sum += chunk.values.sum::<i64>();
                     }
                 }
                 sum
@@ -43,8 +37,8 @@ fn concurrent_iter<I: Iterator<Item = i64>>(
 
 #[test_matrix(
     [1, 8, 64, 256],
-    [4, 8, 16],
-    [1, 8, 71, 1025],
+    [4, 16],
+    [1, 4, 64],
     [false, true]
 )]
 fn consume_iter(len: usize, num_threads: usize, batch: usize, lag: bool) {

--- a/tests/consume_vec.rs
+++ b/tests/consume_vec.rs
@@ -17,14 +17,8 @@ fn concurrent_iter(num_threads: usize, batch: usize, vec: Vec<i64>) {
                         sum += next.value;
                     }
                 } else {
-                    let mut more = true;
-                    while more {
-                        more = false;
-                        let next = iter.next_chunk(batch);
-                        for value in next.values() {
-                            sum += value;
-                            more = true;
-                        }
+                    while let Some(chunk) = iter.next_chunk(batch) {
+                        sum += chunk.values.sum::<i64>();
                     }
                 }
                 sum
@@ -38,9 +32,9 @@ fn concurrent_iter(num_threads: usize, batch: usize, vec: Vec<i64>) {
 }
 
 #[test_matrix(
-    [1, 2, 4, 8, 64, 1024, 64*1024],
-    [4 ,8, 16],
-    [1, 2, 4, 5, 8, 64, 71, 1024, 1025]
+    [1, 4, 1024, 64*1024],
+    [4, 8, 16],
+    [1, 4, 64, 1024]
 )]
 fn consume_vec(len: usize, num_threads: usize, batch: usize) {
     for _ in 0..NUM_RERUNS {
@@ -62,13 +56,9 @@ fn concurrent_iter_heap(num_threads: usize, batch: usize, vec: Vec<String>) {
                         str = next.value;
                     }
                 } else {
-                    let mut more = true;
-                    while more {
-                        more = false;
-                        let next = iter.next_chunk(batch);
-                        for value in next.values() {
+                    while let Some(chunk) = iter.next_chunk(batch) {
+                        for value in chunk.values {
                             str = value;
-                            more = true;
                         }
                     }
                 }
@@ -88,9 +78,9 @@ fn concurrent_iter_heap(num_threads: usize, batch: usize, vec: Vec<String>) {
 }
 
 #[test_matrix(
-    [1, 2, 4, 8, 64, 1024, 4*1024],
-    [4 ,8, 16],
-    [1, 2, 4, 5, 8, 64, 71, 1024, 1025]
+    [1, 4, 1024, 4*1024],
+    [4, 8, 16],
+    [1, 4, 64, 1024]
 )]
 fn consume_vec_heap(len: usize, num_threads: usize, batch: usize) {
     for _ in 0..NUM_RERUNS {

--- a/tests/range.rs
+++ b/tests/range.rs
@@ -95,7 +95,7 @@ fn atomic_exact() {
 
 #[test_matrix(
     [1, 2, 8],
-    [1, 2, 8, 64, 1025, 5483]
+    [1, 2, 64, 1025, 5483]
 )]
 fn ids_and_values(num_threads: usize, len: usize) {
     test_values(num_threads, len, (0..len).con_iter());

--- a/tests/slice.rs
+++ b/tests/slice.rs
@@ -109,7 +109,7 @@ fn atomic_exact() {
 
 #[test_matrix(
     [1, 2, 8],
-    [1, 2, 8, 64, 1025, 5483]
+    [1, 8, 64, 1025, 5483]
 )]
 fn ids_and_values(num_threads: usize, len: usize) {
     let values: Vec<_> = (0..len).collect();


### PR DESCRIPTION
* `BufferedChunk` trait is defined. This trait defines types which pulls from the parent concurrent iterator concurrently while avoiding allocations at every pull. This is a critical requirement in enabling efficient parallel programs using the concurrent iterator.
* `BufferedIter` struct wrapping a `BufferedChunk` is defined. A bufferred iterator can be created by `ConcurrentIter::buffered_iter` method.
* Buffered iterators of all concurrent iterator implementations are provided.
* Now all `next_chunk` calls return an `ExactSizeIterator`. Therefore, there is no need for `next_exact_chunk` separation, which are removed.
* Due to the above revision, we do not need the `loop` with a mutable `has_any_more` flag. We can always use `while let Some(chunk) = iter.next_chunk(n)`. This improves the ergonomy of the iterator significantly.
* `fold` and `for_each` implementations are simplified greatly.
* `next` module is simplified.
* `AtomicIter` is simplified.
* `AtomicIterWithInitialLen` is simplified.