### PR TITLE
`skip_to_end` to establish `early_exit` or shortcut

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-iter"
-version = "1.11.1"
+version = "1.12.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A thread-safe, ergonomic and lightweight concurrent iterator trait and efficient implementations."

--- a/src/iter/atomic_counter.rs
+++ b/src/iter/atomic_counter.rs
@@ -29,6 +29,12 @@ impl AtomicCounter {
     pub fn current(&self) -> usize {
         self.current.load(Ordering::Relaxed)
     }
+
+    /// Updates the value of the current value of the counter as the given `new_value`.
+    #[inline(always)]
+    pub fn store(&self, new_value: usize) {
+        self.current.store(new_value, Ordering::SeqCst)
+    }
 }
 
 impl Default for AtomicCounter {

--- a/src/iter/atomic_iter.rs
+++ b/src/iter/atomic_iter.rs
@@ -27,6 +27,15 @@ pub trait AtomicIter<T: Send + Sync>: Send + Sync {
     /// Returns an iterator of the next `n` **consecutive items** that the iterator yields.
     /// It might return an iterator of less or no items if the iteration does not have sufficient elements left.
     fn fetch_n(&self, n: usize) -> Option<NextChunk<T, impl ExactSizeIterator<Item = T>>>;
+
+    /// Skips all remaining elements of the iterator and assumes that the end of the iterator is reached.
+    ///
+    /// This method establishes a very primitive, convenient and critical communication among threads for search scenarios with an early exit condition.
+    /// Assume, for instance, that we are trying to `find` an element satisfying a predicate using multiple threads.
+    /// Whenever a threads finds a match, it can call this method and return the found value.
+    /// Then, when the other threads try to pull next element from the iterator, they will observe that the iterator has ended.
+    /// Therefore, they will as well return early as desired.
+    fn early_exit(&self);
 }
 
 /// An atomic counter based iterator with exactly known initial length.

--- a/src/iter/implementors/array.rs
+++ b/src/iter/implementors/array.rs
@@ -83,6 +83,10 @@ impl<const N: usize, T: Send + Sync + Default> AtomicIter<T> for ConIterOfArray<
             }
         }
     }
+
+    fn early_exit(&self) {
+        self.counter().store(N)
+    }
 }
 
 impl<const N: usize, T: Send + Sync + Default> AtomicIterWithInitialLen<T>
@@ -131,6 +135,10 @@ impl<const N: usize, T: Send + Sync + Default> ConcurrentIter for ConIterOfArray
     #[inline(always)]
     fn try_get_len(&self) -> Option<usize> {
         Some(<Self as ExactSizeConcurrentIter>::len(self))
+    }
+
+    fn skip_to_end(&self) {
+        self.early_exit()
     }
 }
 

--- a/src/iter/implementors/cloned/slice.rs
+++ b/src/iter/implementors/cloned/slice.rs
@@ -91,6 +91,10 @@ impl<'a, T: Send + Sync + Clone> AtomicIter<T> for ClonedConIterOfSlice<'a, T> {
             }
         }
     }
+
+    fn early_exit(&self) {
+        self.counter().store(self.slice.len())
+    }
 }
 
 impl<'a, T: Send + Sync + Clone> AtomicIterWithInitialLen<T> for ClonedConIterOfSlice<'a, T> {
@@ -132,6 +136,10 @@ impl<'a, T: Send + Sync + Clone> ConcurrentIter for ClonedConIterOfSlice<'a, T> 
     #[inline(always)]
     fn try_get_len(&self) -> Option<usize> {
         Some(<Self as ExactSizeConcurrentIter>::len(self))
+    }
+
+    fn skip_to_end(&self) {
+        self.early_exit()
     }
 }
 

--- a/src/iter/implementors/iter.rs
+++ b/src/iter/implementors/iter.rs
@@ -152,6 +152,11 @@ where
             }
         })
     }
+
+    fn early_exit(&self) {
+        self.counter().store(usize::MAX);
+        self.completed.store(true, atomic::Ordering::SeqCst);
+    }
 }
 
 unsafe impl<T: Send + Sync, Iter> Sync for ConIterOfIter<T, Iter> where Iter: Iterator<Item = T> {}
@@ -189,5 +194,9 @@ where
     #[inline(always)]
     fn try_get_len(&self) -> Option<usize> {
         None
+    }
+
+    fn skip_to_end(&self) {
+        self.early_exit()
     }
 }

--- a/src/iter/implementors/range.rs
+++ b/src/iter/implementors/range.rs
@@ -129,6 +129,10 @@ where
             }
         }
     }
+
+    fn early_exit(&self) {
+        self.counter().store(self.range.end.into())
+    }
 }
 
 impl<Idx> AtomicIterWithInitialLen<Idx> for ConIterOfRange<Idx>
@@ -214,6 +218,10 @@ where
     #[inline(always)]
     fn try_get_len(&self) -> Option<usize> {
         Some(<Self as ExactSizeConcurrentIter>::len(self))
+    }
+
+    fn skip_to_end(&self) {
+        self.early_exit()
     }
 }
 

--- a/src/iter/implementors/slice.rs
+++ b/src/iter/implementors/slice.rs
@@ -91,6 +91,10 @@ impl<'a, T: Send + Sync> AtomicIter<&'a T> for ConIterOfSlice<'a, T> {
             }
         }
     }
+
+    fn early_exit(&self) {
+        self.counter().store(self.slice.len())
+    }
 }
 
 impl<'a, T: Send + Sync> AtomicIterWithInitialLen<&'a T> for ConIterOfSlice<'a, T> {
@@ -132,6 +136,10 @@ impl<'a, T: Send + Sync> ConcurrentIter for ConIterOfSlice<'a, T> {
     #[inline(always)]
     fn try_get_len(&self) -> Option<usize> {
         Some(<Self as ExactSizeConcurrentIter>::len(self))
+    }
+
+    fn skip_to_end(&self) {
+        self.early_exit()
     }
 }
 

--- a/src/iter/implementors/vec.rs
+++ b/src/iter/implementors/vec.rs
@@ -84,6 +84,10 @@ impl<T: Send + Sync + Default> AtomicIter<T> for ConIterOfVec<T> {
             }
         }
     }
+
+    fn early_exit(&self) {
+        self.counter().store(self.vec_len)
+    }
 }
 
 impl<T: Send + Sync + Default> AtomicIterWithInitialLen<T> for ConIterOfVec<T> {
@@ -130,6 +134,10 @@ impl<T: Send + Sync + Default> ConcurrentIter for ConIterOfVec<T> {
     #[inline(always)]
     fn try_get_len(&self) -> Option<usize> {
         Some(<Self as ExactSizeConcurrentIter>::len(self))
+    }
+
+    fn skip_to_end(&self) {
+        self.early_exit()
     }
 }
 

--- a/tests/consume_array.rs
+++ b/tests/consume_array.rs
@@ -5,12 +5,12 @@ const NUM_RERUNS: usize = 1;
 
 fn concurrent_iter(num_threads: usize, batch: usize, array: [i64; 1024]) {
     let expected_sum: i64 = array.iter().sum();
-    let iter = &array.into_con_iter();
+    let iter = array.into_con_iter();
 
     let sum: i64 = std::thread::scope(|s| {
         let mut handles = vec![];
         for _ in 0..num_threads {
-            handles.push(s.spawn(move || {
+            handles.push(s.spawn(|| {
                 let mut sum = 0i64;
                 if batch == 1 {
                     while let Some(next) = iter.next_id_and_value() {

--- a/tests/early_exit.rs
+++ b/tests/early_exit.rs
@@ -1,0 +1,171 @@
+use orx_concurrent_iter::*;
+
+fn test_threads_chunks<F>(test: F)
+where
+    F: Fn(usize, usize),
+{
+    let params = [(1, 1), (4, 1), (1, 4), (2, 64), (4, 32), (8, 16)];
+    for (num_threads, batch) in params {
+        test(num_threads, batch);
+    }
+}
+
+fn predicate(value: &i32) -> bool {
+    *value > 0 && value % 987 == 0
+}
+
+#[test]
+fn early_exit_range() {
+    fn test(num_threads: usize, batch: usize) {
+        let range = 0i32..4096i32;
+        let iter = range.into_con_iter();
+
+        let found = par_find(iter, predicate, num_threads, batch);
+        assert_eq!(found, Some((987, 987)));
+    }
+
+    test_threads_chunks(test)
+}
+
+#[test]
+fn early_exit_vec() {
+    fn test(num_threads: usize, batch: usize) {
+        let vec: Vec<_> = (0..4096).collect();
+        let iter = vec.into_con_iter();
+
+        let found = par_find(iter, predicate, num_threads, batch);
+        assert_eq!(found, Some((987, 987)));
+    }
+
+    test_threads_chunks(test)
+}
+
+#[test]
+fn early_exit_slice_cloned() {
+    fn test(num_threads: usize, batch: usize) {
+        let vec: Vec<_> = (0..4096).collect();
+        let iter = vec.as_slice().into_con_iter().cloned();
+
+        let found = par_find(iter, predicate, num_threads, batch);
+        assert_eq!(found, Some((987, 987)));
+    }
+
+    test_threads_chunks(test)
+}
+
+#[test]
+fn early_exit_array() {
+    fn test(num_threads: usize, batch: usize) {
+        let mut array = [0i32; 4096];
+        for (i, x) in array.iter_mut().enumerate() {
+            *x = i as i32;
+        }
+        let iter = array.into_con_iter();
+
+        let found = par_find(iter, predicate, num_threads, batch);
+        assert_eq!(found, Some((987, 987)));
+    }
+
+    test_threads_chunks(test)
+}
+
+#[test]
+fn early_exit_iter() {
+    fn test(num_threads: usize, batch: usize) {
+        let range = -1000i32..14096i32;
+        let iter = range.skip(54).filter(|x| *x >= 0).take(4096);
+        let iter = iter.into_con_iter();
+
+        let found = par_find(iter, predicate, num_threads, batch);
+        assert_eq!(found, Some((987, 987)));
+    }
+
+    test_threads_chunks(test)
+}
+
+#[test]
+fn early_exit_slice() {
+    fn test(num_threads: usize, batch: usize) {
+        let vec: Vec<_> = (0..4096).collect();
+        let iter = vec.as_slice().into_con_iter();
+
+        let found = std::thread::scope(|s| {
+            let mut handles = vec![];
+            for _ in 0..num_threads {
+                handles.push(s.spawn(|| {
+                    if batch == 1 {
+                        while let Some(next) = iter.next_id_and_value() {
+                            if predicate(next.value) {
+                                iter.skip_to_end();
+                                return Some((next.idx, *next.value));
+                            }
+                        }
+                    } else {
+                        while let Some(chunk) = iter.next_chunk(batch) {
+                            for (i, x) in chunk.values.enumerate() {
+                                if predicate(x) {
+                                    iter.skip_to_end();
+                                    return Some((chunk.begin_idx + i, *x));
+                                }
+                            }
+                        }
+                    }
+                    None
+                }));
+            }
+
+            let collected: Vec<_> = handles
+                .into_iter()
+                .flat_map(|x| x.join().expect("-"))
+                .collect();
+
+            assert_eq!(collected.len(), 1, "early exit failed");
+            collected[0]
+        });
+
+        assert_eq!(found, (987, 987));
+    }
+
+    test_threads_chunks(test)
+}
+
+fn par_find<I, P>(iter: I, predicate: P, num_threads: usize, batch: usize) -> Option<(usize, i32)>
+where
+    I: ConcurrentIter<Item = i32>,
+    P: Fn(&i32) -> bool + Send + Sync,
+{
+    std::thread::scope(|s| {
+        let mut handles = vec![];
+        for _ in 0..num_threads {
+            handles.push(s.spawn(|| {
+                if batch == 1 {
+                    while let Some(next) = iter.next_id_and_value() {
+                        if predicate(&next.value) {
+                            iter.skip_to_end();
+                            return Some((next.idx, next.value));
+                        }
+                    }
+                } else {
+                    while let Some(chunk) = iter.next_chunk(batch) {
+                        for (i, x) in chunk.values.enumerate() {
+                            if predicate(&x) {
+                                iter.skip_to_end();
+                                return Some((chunk.begin_idx + i, x));
+                            }
+                        }
+                    }
+                }
+                None
+            }));
+        }
+
+        let results: Vec<_> = handles
+            .into_iter()
+            .flat_map(|x| x.join().expect("-"))
+            .collect();
+
+        assert_eq!(results.len(), 1, "early exit failed");
+
+        results.into_iter().min_by_key(|x| x.0)
+    })
+}


### PR DESCRIPTION
* `early_exit` method is added to `AtomicIter`.
* Its counterpart `skip_to_end` is added to `ConcurrentIter`.

These two methods allow primitive communication among threads signaling them that the job is done and they can early return. This is critical in preventing doing unnecessary work.