### PR TITLE
feat: into_seq_iter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-iter"
-version = "1.12.5"
+version = "1.13.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A thread-safe, ergonomic and lightweight concurrent iterator trait and efficient implementations."

--- a/src/iter/con_iter.rs
+++ b/src/iter/con_iter.rs
@@ -16,6 +16,16 @@ pub trait ConcurrentIter: Send + Sync {
     /// Type of the buffered iterator returned by the `chunk_iter` method when elements are fetched in chunks by each thread.
     type BufferedIter: BufferedChunk<Self::Item, ConIter = Self>;
 
+    /// Type of the items that the `SeqIter` yields.
+    type SeqIterItem;
+
+    /// Inner type which sources the data to be iterated.
+    type SeqIter: Iterator<Item = Self::SeqIterItem>;
+
+    /// Converts the concurrent iterator back to the original wrapped type which is the source of the elements to be iterated.
+    /// Already progressed elements are skipped.
+    fn into_seq_iter(self) -> Self::SeqIter;
+
     /// Advances the iterator and returns the next value together with its enumeration index.
     ///
     /// Returns [None] when iteration is finished.

--- a/src/iter/implementors/array.rs
+++ b/src/iter/implementors/array.rs
@@ -114,6 +114,51 @@ impl<const N: usize, T: Send + Sync + Default> ConcurrentIter for ConIterOfArray
 
     type BufferedIter = BufferedArray<N>;
 
+    type SeqIterItem = T;
+
+    type SeqIter = std::iter::Skip<std::array::IntoIter<T, N>>;
+
+    /// Converts the concurrent iterator back to the original wrapped type which is the source of the elements to be iterated.
+    /// Already progressed elements are skipped.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use orx_concurrent_iter::*;
+    ///
+    /// let mut array = [0; 1024];
+    /// for (i, x) in array.iter_mut().enumerate() {
+    ///     *x = i;
+    /// }
+    /// let con_iter = array.into_con_iter();
+    ///
+    /// std::thread::scope(|s| {
+    ///     s.spawn(|| {
+    ///         for _ in 0..42 {
+    ///             _ = con_iter.next();
+    ///         }
+    ///
+    ///         let mut buffered = con_iter.buffered_iter(32);
+    ///         let _chunk = buffered.next().unwrap();
+    ///     });
+    /// });
+    ///
+    /// let num_used = 42 + 32;
+    ///
+    /// // converts the remaining elements into a sequential iterator
+    /// let seq_iter = con_iter.into_seq_iter();
+    ///
+    /// assert_eq!(seq_iter.len(), 1024 - num_used);
+    /// for (i, x) in seq_iter.enumerate() {
+    ///     assert_eq!(x, num_used + i);
+    /// }
+    /// ```
+    fn into_seq_iter(self) -> Self::SeqIter {
+        let current = self.counter().current();
+        let array = self.array.into_inner();
+        array.into_iter().skip(current)
+    }
+
     #[inline(always)]
     fn next_id_and_value(&self) -> Option<Next<Self::Item>> {
         self.fetch_one()

--- a/src/iter/implementors/cloned/slice.rs
+++ b/src/iter/implementors/cloned/slice.rs
@@ -115,6 +115,48 @@ impl<'a, T: Send + Sync + Clone> ConcurrentIter for ClonedConIterOfSlice<'a, T> 
 
     type BufferedIter = BufferedSliceCloned<'a>;
 
+    type SeqIterItem = &'a T;
+
+    type SeqIter = std::iter::Skip<std::slice::Iter<'a, T>>;
+
+    /// Converts the concurrent iterator back to the original wrapped type which is the source of the elements to be iterated.
+    /// Already progressed elements are skipped.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use orx_concurrent_iter::*;
+    ///
+    /// let vec: Vec<_> = (0..1024).map(|x| x.to_string()).collect();
+    /// let slice = vec.as_slice();
+    /// let con_iter = slice.into_con_iter().cloned();
+    ///
+    /// std::thread::scope(|s| {
+    ///     s.spawn(|| {
+    ///         for _ in 0..42 {
+    ///             _ = con_iter.next();
+    ///         }
+    ///
+    ///         let mut buffered = con_iter.buffered_iter(32);
+    ///         let _chunk = buffered.next().unwrap();
+    ///     });
+    /// });
+    ///
+    /// let num_used = 42 + 32;
+    ///
+    /// // converts the remaining elements into a sequential iterator
+    /// let seq_iter = con_iter.into_seq_iter();
+    ///
+    /// assert_eq!(seq_iter.len(), 1024 - num_used);
+    /// for (i, x) in seq_iter.enumerate() {
+    ///     assert_eq!(x, &(num_used + i).to_string());
+    /// }
+    /// ```
+    fn into_seq_iter(self) -> Self::SeqIter {
+        let current = self.counter().current();
+        self.slice.into_iter().skip(current)
+    }
+
     #[inline(always)]
     fn next_id_and_value(&self) -> Option<Next<Self::Item>> {
         self.fetch_one()

--- a/src/iter/implementors/range.rs
+++ b/src/iter/implementors/range.rs
@@ -197,6 +197,47 @@ where
 
     type BufferedIter = BufferedRange;
 
+    type SeqIterItem = usize;
+
+    type SeqIter = Range<usize>;
+
+    /// Converts the concurrent iterator back to the original wrapped type which is the source of the elements to be iterated.
+    /// Already progressed elements are skipped.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use orx_concurrent_iter::*;
+    ///
+    /// let range = 0..1024;
+    /// let con_iter = range.con_iter();
+    ///
+    /// std::thread::scope(|s| {
+    ///     s.spawn(|| {
+    ///         for _ in 0..42 {
+    ///             _ = con_iter.next();
+    ///         }
+    ///
+    ///         let mut buffered = con_iter.buffered_iter(32);
+    ///         let _chunk = buffered.next().unwrap();
+    ///     });
+    /// });
+    ///
+    /// let num_used = 42 + 32;
+    ///
+    /// // converts the remaining elements into a sequential iterator
+    /// let seq_iter = con_iter.into_seq_iter();
+    ///
+    /// assert_eq!(seq_iter.len(), 1024 - num_used);
+    /// for (i, x) in seq_iter.enumerate() {
+    ///     assert_eq!(x, num_used + i);
+    /// }
+    /// ```
+    fn into_seq_iter(self) -> Self::SeqIter {
+        let current = self.counter().current();
+        current..self.range.end.into()
+    }
+
     #[inline(always)]
     fn next_id_and_value(&self) -> Option<Next<Self::Item>> {
         self.fetch_one()

--- a/src/iter/implementors/slice.rs
+++ b/src/iter/implementors/slice.rs
@@ -115,6 +115,48 @@ impl<'a, T: Send + Sync> ConcurrentIter for ConIterOfSlice<'a, T> {
 
     type BufferedIter = BufferedSlice;
 
+    type SeqIterItem = &'a T;
+
+    type SeqIter = std::iter::Skip<std::slice::Iter<'a, T>>;
+
+    /// Converts the concurrent iterator back to the original wrapped type which is the source of the elements to be iterated.
+    /// Already progressed elements are skipped.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use orx_concurrent_iter::*;
+    ///
+    /// let vec: Vec<_> = (0..1024).map(|x| x.to_string()).collect();
+    /// let slice = vec.as_slice();
+    /// let con_iter = slice.into_con_iter();
+    ///
+    /// std::thread::scope(|s| {
+    ///     s.spawn(|| {
+    ///         for _ in 0..42 {
+    ///             _ = con_iter.next();
+    ///         }
+    ///
+    ///         let mut buffered = con_iter.buffered_iter(32);
+    ///         let _chunk = buffered.next().unwrap();
+    ///     });
+    /// });
+    ///
+    /// let num_used = 42 + 32;
+    ///
+    /// // converts the remaining elements into a sequential iterator
+    /// let seq_iter = con_iter.into_seq_iter();
+    ///
+    /// assert_eq!(seq_iter.len(), 1024 - num_used);
+    /// for (i, x) in seq_iter.enumerate() {
+    ///     assert_eq!(x, &(num_used + i).to_string());
+    /// }
+    /// ```
+    fn into_seq_iter(self) -> Self::SeqIter {
+        let current = self.counter().current();
+        self.slice.into_iter().skip(current)
+    }
+
     #[inline(always)]
     fn next_id_and_value(&self) -> Option<Next<Self::Item>> {
         self.fetch_one()

--- a/src/iter/implementors/vec.rs
+++ b/src/iter/implementors/vec.rs
@@ -113,6 +113,48 @@ impl<T: Send + Sync + Default> ConcurrentIter for ConIterOfVec<T> {
 
     type BufferedIter = BufferedVec;
 
+    type SeqIterItem = T;
+
+    type SeqIter = std::iter::Skip<std::vec::IntoIter<T>>;
+
+    /// Converts the concurrent iterator back to the original wrapped type which is the source of the elements to be iterated.
+    /// Already progressed elements are skipped.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use orx_concurrent_iter::*;
+    ///
+    /// let vec: Vec<_> = (0..1024).map(|x| x.to_string()).collect();
+    /// let con_iter = vec.into_con_iter();
+    ///
+    /// std::thread::scope(|s| {
+    ///     s.spawn(|| {
+    ///         for _ in 0..42 {
+    ///             _ = con_iter.next();
+    ///         }
+    ///
+    ///         let mut buffered = con_iter.buffered_iter(32);
+    ///         let _chunk = buffered.next().unwrap();
+    ///     });
+    /// });
+    ///
+    /// let num_used = 42 + 32;
+    ///
+    /// // converts the remaining elements into a sequential iterator
+    /// let seq_iter = con_iter.into_seq_iter();
+    ///
+    /// assert_eq!(seq_iter.len(), 1024 - num_used);
+    /// for (i, x) in seq_iter.enumerate() {
+    ///     assert_eq!(x, (num_used + i).to_string());
+    /// }
+    /// ```
+    fn into_seq_iter(self) -> Self::SeqIter {
+        let current = self.counter().current();
+        let vec = self.vec.into_inner();
+        vec.into_iter().skip(current)
+    }
+
     #[inline(always)]
     fn next_id_and_value(&self) -> Option<Next<Self::Item>> {
         self.fetch_one()

--- a/tests/from_cloned_slice.rs
+++ b/tests/from_cloned_slice.rs
@@ -3,47 +3,33 @@ use orx_concurrent_iter::*;
 #[test]
 fn con_iter() {
     let values = ['a', 'b', 'c'];
+    let slice = values.as_slice();
 
-    let con_iter = values.con_iter();
-    assert_eq!(con_iter.next(), Some(&'a'));
-    assert_eq!(con_iter.next(), Some(&'b'));
-    assert_eq!(con_iter.next(), Some(&'c'));
-    assert_eq!(con_iter.next(), None);
-}
-
-#[test]
-fn into_con_iter() {
-    let values = ['a', 'b', 'c'];
-
-    let con_iter = values.into_con_iter();
+    let con_iter = slice.con_iter().cloned();
     assert_eq!(con_iter.next(), Some('a'));
     assert_eq!(con_iter.next(), Some('b'));
     assert_eq!(con_iter.next(), Some('c'));
     assert_eq!(con_iter.next(), None);
 
-    let con_iter = values.into_exact_con_iter();
+    let con_iter = slice.into_con_iter().cloned();
     assert_eq!(con_iter.next(), Some('a'));
     assert_eq!(con_iter.next(), Some('b'));
     assert_eq!(con_iter.next(), Some('c'));
     assert_eq!(con_iter.next(), None);
 
-    let con_iter = values.into_iter().take(2).into_con_iter();
+    let con_iter = slice.into_exact_con_iter().cloned();
     assert_eq!(con_iter.next(), Some('a'));
     assert_eq!(con_iter.next(), Some('b'));
+    assert_eq!(con_iter.next(), Some('c'));
     assert_eq!(con_iter.next(), None);
-}
-
-#[test]
-fn exact_len() {
-    let values = ['a', 'b', 'c'];
-    assert_eq!(3, values.exact_len())
 }
 
 #[test]
 fn len() {
-    let values = ['a', 'b', 'c', 'd'];
+    let values = vec!['a', 'b', 'c', 'd'];
+    let slice = values.as_slice();
 
-    let iter = values.into_con_iter();
+    let iter = slice.con_iter().cloned();
     assert_eq!(iter.len(), 4);
     assert_eq!(iter.try_get_len(), Some(4));
 
@@ -66,26 +52,22 @@ fn len() {
 
 #[test]
 fn into_seq_iter_unused() {
-    let mut array = [0; 1024];
-    for (i, x) in array.iter_mut().enumerate() {
-        *x = i;
-    }
-    let con_iter = array.into_con_iter();
+    let vec: Vec<_> = (0..1024).map(|x| x.to_string()).collect();
+    let slice = vec.as_slice();
+    let con_iter = slice.into_con_iter();
     let seq_iter = con_iter.into_seq_iter();
 
     assert_eq!(seq_iter.len(), 1024);
     for (i, x) in seq_iter.enumerate() {
-        assert_eq!(x, i);
+        assert_eq!(x, &i.to_string());
     }
 }
 
 #[test]
 fn into_seq_iter_used_singly() {
-    let mut array = [0; 1024];
-    for (i, x) in array.iter_mut().enumerate() {
-        *x = i;
-    }
-    let con_iter = array.into_con_iter();
+    let vec: Vec<_> = (0..1024).map(|x| x.to_string()).collect();
+    let slice = vec.as_slice();
+    let con_iter = slice.into_con_iter().cloned();
 
     std::thread::scope(|s| {
         s.spawn(|| {
@@ -99,17 +81,15 @@ fn into_seq_iter_used_singly() {
 
     assert_eq!(seq_iter.len(), 1024 - 114);
     for (i, x) in seq_iter.enumerate() {
-        assert_eq!(x, 114 + i);
+        assert_eq!(x, &(114 + i).to_string());
     }
 }
 
 #[test]
 fn into_seq_iter_used_in_batches() {
-    let mut array = [0; 1024];
-    for (i, x) in array.iter_mut().enumerate() {
-        *x = i;
-    }
-    let con_iter = array.into_con_iter();
+    let vec: Vec<_> = (0..1024).map(|x| x.to_string()).collect();
+    let slice = vec.as_slice();
+    let con_iter = slice.into_con_iter().cloned();
 
     std::thread::scope(|s| {
         s.spawn(|| {
@@ -127,17 +107,15 @@ fn into_seq_iter_used_in_batches() {
 
     assert_eq!(seq_iter.len(), 1024 - 44 - 33);
     for (i, x) in seq_iter.enumerate() {
-        assert_eq!(x, 44 + 33 + i);
+        assert_eq!(x, &(44 + 33 + i).to_string());
     }
 }
 
 #[test]
 fn into_seq_iter_doc() {
-    let mut array = [0; 1024];
-    for (i, x) in array.iter_mut().enumerate() {
-        *x = i;
-    }
-    let con_iter = array.into_con_iter();
+    let vec: Vec<_> = (0..1024).map(|x| x.to_string()).collect();
+    let slice = vec.as_slice();
+    let con_iter = slice.into_con_iter().cloned();
 
     std::thread::scope(|s| {
         s.spawn(|| {
@@ -157,6 +135,6 @@ fn into_seq_iter_doc() {
 
     assert_eq!(seq_iter.len(), 1024 - num_used);
     for (i, x) in seq_iter.enumerate() {
-        assert_eq!(x, num_used + i);
+        assert_eq!(x, &(num_used + i).to_string());
     }
 }

--- a/tests/from_iter.rs
+++ b/tests/from_iter.rs
@@ -55,3 +55,88 @@ fn len() {
     _ = con_iter.next();
     assert_eq!(con_iter.try_get_len(), None);
 }
+
+#[test]
+fn into_seq_iter_unused() {
+    let iter = (0..1024).map(|x| x.to_string());
+    let con_iter = iter.into_con_iter();
+    let seq_iter = con_iter.into_seq_iter();
+
+    assert_eq!(seq_iter.len(), 1024);
+    for (i, x) in seq_iter.enumerate() {
+        assert_eq!(x, i.to_string());
+    }
+}
+
+#[test]
+fn into_seq_iter_used_singly() {
+    let iter = (0..1024).map(|x| x.to_string());
+    let con_iter = iter.into_con_iter();
+
+    std::thread::scope(|s| {
+        s.spawn(|| {
+            for _ in 0..114 {
+                _ = con_iter.next();
+            }
+        });
+    });
+
+    let seq_iter = con_iter.into_seq_iter();
+
+    assert_eq!(seq_iter.len(), 1024 - 114);
+    for (i, x) in seq_iter.enumerate() {
+        assert_eq!(x, (114 + i).to_string());
+    }
+}
+
+#[test]
+fn into_seq_iter_used_in_batches() {
+    let iter = (0..1024).map(|x| x.to_string());
+    let con_iter = iter.into_con_iter();
+
+    std::thread::scope(|s| {
+        s.spawn(|| {
+            if let Some(batch) = con_iter.next_chunk(44) {
+                for _ in batch.values {}
+            }
+
+            if let Some(batch) = con_iter.next_chunk(33) {
+                for _ in batch.values.take(22) {}
+            }
+        });
+    });
+
+    let seq_iter = con_iter.into_seq_iter();
+
+    assert_eq!(seq_iter.len(), 1024 - 44 - 33);
+    for (i, x) in seq_iter.enumerate() {
+        assert_eq!(x, (44 + 33 + i).to_string());
+    }
+}
+
+#[test]
+fn into_seq_iter_doc() {
+    let iter = (0..1024).map(|x| x.to_string());
+    let con_iter = iter.into_con_iter();
+
+    std::thread::scope(|s| {
+        s.spawn(|| {
+            for _ in 0..42 {
+                _ = con_iter.next();
+            }
+
+            let mut buffered = con_iter.buffered_iter(32);
+            let _chunk = buffered.next().unwrap();
+        });
+    });
+
+    let num_used = 42 + 32;
+
+    // converts the remaining elements into a sequential iterator
+    let seq_iter = con_iter.into_seq_iter();
+
+    assert_eq!(seq_iter.len(), 1024 - num_used);
+    for (i, x) in seq_iter.enumerate() {
+        assert_eq!(x, (num_used + i).to_string());
+    }
+}

--- a/tests/from_range.rs
+++ b/tests/from_range.rs
@@ -1,7 +1,4 @@
-use orx_concurrent_iter::{
-    ConIterOfIter, ConIterOfRange, ConcurrentIter, ConcurrentIterable, ExactSizeConcurrentIter,
-    IntoConcurrentIter, IntoExactSizeConcurrentIter,
-};
+use orx_concurrent_iter::*;
 
 #[test]
 fn con_iter() {
@@ -13,7 +10,7 @@ fn con_iter() {
     assert_eq!(con_iter.next(), Some(44));
     assert_eq!(con_iter.next(), None);
 
-    let con_iter: ConIterOfRange<_> = values.clone().into_con_iter();
+    let con_iter: ConIterOfRange<_> = values.clone().con_iter();
     assert_eq!(con_iter.next(), Some(42));
     assert_eq!(con_iter.next(), Some(43));
     assert_eq!(con_iter.next(), Some(44));
@@ -67,4 +64,89 @@ fn len() {
     _ = iter.next();
     assert_eq!(iter.len(), 0);
     assert_eq!(iter.try_get_len(), Some(0));
+}
+
+#[test]
+fn into_seq_iter_unused() {
+    let range = 0..1024;
+    let con_iter = range.con_iter();
+    let seq_iter = con_iter.into_seq_iter();
+
+    assert_eq!(seq_iter.len(), 1024);
+    for (i, x) in seq_iter.enumerate() {
+        assert_eq!(x, i);
+    }
+}
+
+#[test]
+fn into_seq_iter_used_singly() {
+    let range = 0..1024;
+    let con_iter = range.con_iter();
+
+    std::thread::scope(|s| {
+        s.spawn(|| {
+            for _ in 0..114 {
+                _ = con_iter.next();
+            }
+        });
+    });
+
+    let seq_iter = con_iter.into_seq_iter();
+
+    assert_eq!(seq_iter.len(), 1024 - 114);
+    for (i, x) in seq_iter.enumerate() {
+        assert_eq!(x, 114 + i);
+    }
+}
+
+#[test]
+fn into_seq_iter_used_in_batches() {
+    let range = 0..1024;
+    let con_iter = range.con_iter();
+
+    std::thread::scope(|s| {
+        s.spawn(|| {
+            if let Some(batch) = con_iter.next_chunk(44) {
+                for _ in batch.values {}
+            }
+
+            if let Some(batch) = con_iter.next_chunk(33) {
+                for _ in batch.values.take(22) {}
+            }
+        });
+    });
+
+    let seq_iter = con_iter.into_seq_iter();
+
+    assert_eq!(seq_iter.len(), 1024 - 44 - 33);
+    for (i, x) in seq_iter.enumerate() {
+        assert_eq!(x, 44 + 33 + i);
+    }
+}
+
+#[test]
+fn into_seq_iter_doc() {
+    let range = 0..1024;
+    let con_iter = range.con_iter();
+
+    std::thread::scope(|s| {
+        s.spawn(|| {
+            for _ in 0..42 {
+                _ = con_iter.next();
+            }
+
+            let mut buffered = con_iter.buffered_iter(32);
+            let _chunk = buffered.next().unwrap();
+        });
+    });
+
+    let num_used = 42 + 32;
+
+    // converts the remaining elements into a sequential iterator
+    let seq_iter = con_iter.into_seq_iter();
+
+    assert_eq!(seq_iter.len(), 1024 - num_used);
+    for (i, x) in seq_iter.enumerate() {
+        assert_eq!(x, num_used + i);
+    }
 }

--- a/tests/from_slice.rs
+++ b/tests/from_slice.rs
@@ -56,3 +56,92 @@ fn len() {
     assert_eq!(iter.len(), 0);
     assert_eq!(iter.try_get_len(), Some(0));
 }
+
+#[test]
+fn into_seq_iter_unused() {
+    let vec: Vec<_> = (0..1024).map(|x| x.to_string()).collect();
+    let slice = vec.as_slice();
+    let con_iter = slice.into_con_iter();
+    let seq_iter = con_iter.into_seq_iter();
+
+    assert_eq!(seq_iter.len(), 1024);
+    for (i, x) in seq_iter.enumerate() {
+        assert_eq!(x, &i.to_string());
+    }
+}
+
+#[test]
+fn into_seq_iter_used_singly() {
+    let vec: Vec<_> = (0..1024).map(|x| x.to_string()).collect();
+    let slice = vec.as_slice();
+    let con_iter = slice.into_con_iter();
+
+    std::thread::scope(|s| {
+        s.spawn(|| {
+            for _ in 0..114 {
+                _ = con_iter.next();
+            }
+        });
+    });
+
+    let seq_iter = con_iter.into_seq_iter();
+
+    assert_eq!(seq_iter.len(), 1024 - 114);
+    for (i, x) in seq_iter.enumerate() {
+        assert_eq!(x, &(114 + i).to_string());
+    }
+}
+
+#[test]
+fn into_seq_iter_used_in_batches() {
+    let vec: Vec<_> = (0..1024).map(|x| x.to_string()).collect();
+    let slice = vec.as_slice();
+    let con_iter = slice.into_con_iter();
+
+    std::thread::scope(|s| {
+        s.spawn(|| {
+            if let Some(batch) = con_iter.next_chunk(44) {
+                for _ in batch.values {}
+            }
+
+            if let Some(batch) = con_iter.next_chunk(33) {
+                for _ in batch.values.take(22) {}
+            }
+        });
+    });
+
+    let seq_iter = con_iter.into_seq_iter();
+
+    assert_eq!(seq_iter.len(), 1024 - 44 - 33);
+    for (i, x) in seq_iter.enumerate() {
+        assert_eq!(x, &(44 + 33 + i).to_string());
+    }
+}
+
+#[test]
+fn into_seq_iter_doc() {
+    let vec: Vec<_> = (0..1024).map(|x| x.to_string()).collect();
+    let slice = vec.as_slice();
+    let con_iter = slice.into_con_iter();
+
+    std::thread::scope(|s| {
+        s.spawn(|| {
+            for _ in 0..42 {
+                _ = con_iter.next();
+            }
+
+            let mut buffered = con_iter.buffered_iter(32);
+            let _chunk = buffered.next().unwrap();
+        });
+    });
+
+    let num_used = 42 + 32;
+
+    // converts the remaining elements into a sequential iterator
+    let seq_iter = con_iter.into_seq_iter();
+
+    assert_eq!(seq_iter.len(), 1024 - num_used);
+    for (i, x) in seq_iter.enumerate() {
+        assert_eq!(x, &(num_used + i).to_string());
+    }
+}


### PR DESCRIPTION
`ConcurrentIter:into_seq_iter` trait method is defined and implemented for the source types. This method allows to consume the concurrent iterator and convert it into a sequential iterator for the remaining elements.

Closes #28 