### PR TITLE
fix: seq-iter-yields-same-element-type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-iter"
-version = "1.13.0"
+version = "1.13.1"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A thread-safe, ergonomic and lightweight concurrent iterator trait and efficient implementations."

--- a/src/iter/buffered/range.rs
+++ b/src/iter/buffered/range.rs
@@ -2,7 +2,7 @@ use super::buffered_chunk::BufferedChunk;
 use crate::ConIterOfRange;
 use std::{
     cmp::Ordering,
-    ops::{Add, Sub},
+    ops::{Add, Range, Sub},
 };
 
 pub struct BufferedRange {
@@ -26,6 +26,7 @@ where
         + Add<Idx, Output = Idx>
         + Sub<Idx, Output = Idx>
         + Ord,
+    Range<Idx>: Iterator<Item = Idx>,
 {
     type ConIter = ConIterOfRange<Idx>;
 

--- a/src/iter/con_iter.rs
+++ b/src/iter/con_iter.rs
@@ -16,11 +16,8 @@ pub trait ConcurrentIter: Send + Sync {
     /// Type of the buffered iterator returned by the `chunk_iter` method when elements are fetched in chunks by each thread.
     type BufferedIter: BufferedChunk<Self::Item, ConIter = Self>;
 
-    /// Type of the items that the `SeqIter` yields.
-    type SeqIterItem;
-
-    /// Inner type which sources the data to be iterated.
-    type SeqIter: Iterator<Item = Self::SeqIterItem>;
+    /// Inner type which is the source of the data to be iterated, which in addition is a regular sequential `Iterator`.
+    type SeqIter: Iterator<Item = Self::Item>;
 
     /// Converts the concurrent iterator back to the original wrapped type which is the source of the elements to be iterated.
     /// Already progressed elements are skipped.

--- a/src/iter/constructors/implementors/range.rs
+++ b/src/iter/constructors/implementors/range.rs
@@ -20,6 +20,7 @@ where
         + Add<Idx, Output = Idx>
         + Sub<Idx, Output = Idx>
         + Ord,
+    Range<Idx>: Iterator<Item = Idx>,
 {
     type Item<'i> = Idx where Self: 'i;
 
@@ -41,6 +42,7 @@ where
         + Add<Idx, Output = Idx>
         + Sub<Idx, Output = Idx>
         + Ord,
+    Range<Idx>: Iterator<Item = Idx>,
 {
     type Item = Idx;
 
@@ -67,6 +69,7 @@ where
         + Add<Idx, Output = Idx>
         + Sub<Idx, Output = Idx>
         + Ord,
+    Range<Idx>: Iterator<Item = Idx>,
 {
     type Item = Idx;
 

--- a/src/iter/implementors/array.rs
+++ b/src/iter/implementors/array.rs
@@ -114,8 +114,6 @@ impl<const N: usize, T: Send + Sync + Default> ConcurrentIter for ConIterOfArray
 
     type BufferedIter = BufferedArray<N>;
 
-    type SeqIterItem = T;
-
     type SeqIter = std::iter::Skip<std::array::IntoIter<T, N>>;
 
     /// Converts the concurrent iterator back to the original wrapped type which is the source of the elements to be iterated.

--- a/src/iter/implementors/cloned/slice.rs
+++ b/src/iter/implementors/cloned/slice.rs
@@ -115,9 +115,7 @@ impl<'a, T: Send + Sync + Clone> ConcurrentIter for ClonedConIterOfSlice<'a, T> 
 
     type BufferedIter = BufferedSliceCloned<'a>;
 
-    type SeqIterItem = &'a T;
-
-    type SeqIter = std::iter::Skip<std::slice::Iter<'a, T>>;
+    type SeqIter = std::iter::Cloned<std::iter::Skip<std::slice::Iter<'a, T>>>;
 
     /// Converts the concurrent iterator back to the original wrapped type which is the source of the elements to be iterated.
     /// Already progressed elements are skipped.
@@ -149,12 +147,12 @@ impl<'a, T: Send + Sync + Clone> ConcurrentIter for ClonedConIterOfSlice<'a, T> 
     ///
     /// assert_eq!(seq_iter.len(), 1024 - num_used);
     /// for (i, x) in seq_iter.enumerate() {
-    ///     assert_eq!(x, &(num_used + i).to_string());
+    ///     assert_eq!(x, (num_used + i).to_string());
     /// }
     /// ```
     fn into_seq_iter(self) -> Self::SeqIter {
         let current = self.counter().current();
-        self.slice.into_iter().skip(current)
+        self.slice.into_iter().skip(current).cloned()
     }
 
     #[inline(always)]

--- a/src/iter/implementors/iter.rs
+++ b/src/iter/implementors/iter.rs
@@ -173,8 +173,6 @@ where
 
     type BufferedIter = BufferIter<T, Iter>;
 
-    type SeqIterItem = T;
-
     type SeqIter = Iter;
 
     /// Converts the concurrent iterator back to the original wrapped type which is the source of the elements to be iterated.

--- a/src/iter/implementors/range.rs
+++ b/src/iter/implementors/range.rs
@@ -24,6 +24,7 @@ where
         + Add<Idx, Output = Idx>
         + Sub<Idx, Output = Idx>
         + Ord,
+    Range<Idx>: Iterator<Item = Idx>,
 {
     range: Range<Idx>,
     counter: AtomicCounter,
@@ -40,6 +41,7 @@ where
         + Add<Idx, Output = Idx>
         + Sub<Idx, Output = Idx>
         + Ord,
+    Range<Idx>: Iterator<Item = Idx>,
 {
     /// Creates a concurrent iterator for the given `range`.
     pub fn new(range: Range<Idx>) -> Self {
@@ -65,6 +67,7 @@ where
         + Add<Idx, Output = Idx>
         + Sub<Idx, Output = Idx>
         + Ord,
+    Range<Idx>: Iterator<Item = Idx>,
 {
     /// Creates a concurrent iterator for the given `range`.
     fn from(range: Range<Idx>) -> Self {
@@ -83,6 +86,7 @@ where
         + Add<Idx, Output = Idx>
         + Sub<Idx, Output = Idx>
         + Ord,
+    Range<Idx>: Iterator<Item = Idx>,
 {
     #[inline(always)]
     fn counter(&self) -> &AtomicCounter {
@@ -146,6 +150,7 @@ where
         + Add<Idx, Output = Idx>
         + Sub<Idx, Output = Idx>
         + Ord,
+    Range<Idx>: Iterator<Item = Idx>,
 {
     #[inline(always)]
     fn initial_len(&self) -> usize {
@@ -153,7 +158,8 @@ where
     }
 }
 
-unsafe impl<Idx> Sync for ConIterOfRange<Idx> where
+unsafe impl<Idx> Sync for ConIterOfRange<Idx>
+where
     Idx: Send
         + Sync
         + Clone
@@ -162,11 +168,13 @@ unsafe impl<Idx> Sync for ConIterOfRange<Idx> where
         + Into<usize>
         + Add<Idx, Output = Idx>
         + Sub<Idx, Output = Idx>
-        + Ord
+        + Ord,
+    Range<Idx>: Iterator<Item = Idx>,
 {
 }
 
-unsafe impl<Idx> Send for ConIterOfRange<Idx> where
+unsafe impl<Idx> Send for ConIterOfRange<Idx>
+where
     Idx: Send
         + Sync
         + Clone
@@ -175,7 +183,8 @@ unsafe impl<Idx> Send for ConIterOfRange<Idx> where
         + Into<usize>
         + Add<Idx, Output = Idx>
         + Sub<Idx, Output = Idx>
-        + Ord
+        + Ord,
+    Range<Idx>: Iterator<Item = Idx>,
 {
 }
 
@@ -192,14 +201,13 @@ where
         + Add<Idx, Output = Idx>
         + Sub<Idx, Output = Idx>
         + Ord,
+    Range<Idx>: Iterator<Item = Idx>,
 {
     type Item = Idx;
 
     type BufferedIter = BufferedRange;
 
-    type SeqIterItem = usize;
-
-    type SeqIter = Range<usize>;
+    type SeqIter = Range<Idx>;
 
     /// Converts the concurrent iterator back to the original wrapped type which is the source of the elements to be iterated.
     /// Already progressed elements are skipped.
@@ -235,7 +243,7 @@ where
     /// ```
     fn into_seq_iter(self) -> Self::SeqIter {
         let current = self.counter().current();
-        current..self.range.end.into()
+        current.into()..self.range.end
     }
 
     #[inline(always)]
@@ -277,6 +285,7 @@ where
         + Add<Idx, Output = Idx>
         + Sub<Idx, Output = Idx>
         + Ord,
+    Range<Idx>: Iterator<Item = Idx>,
 {
     #[inline(always)]
     fn len(&self) -> usize {

--- a/src/iter/implementors/slice.rs
+++ b/src/iter/implementors/slice.rs
@@ -115,8 +115,6 @@ impl<'a, T: Send + Sync> ConcurrentIter for ConIterOfSlice<'a, T> {
 
     type BufferedIter = BufferedSlice;
 
-    type SeqIterItem = &'a T;
-
     type SeqIter = std::iter::Skip<std::slice::Iter<'a, T>>;
 
     /// Converts the concurrent iterator back to the original wrapped type which is the source of the elements to be iterated.

--- a/src/iter/implementors/vec.rs
+++ b/src/iter/implementors/vec.rs
@@ -113,8 +113,6 @@ impl<T: Send + Sync + Default> ConcurrentIter for ConIterOfVec<T> {
 
     type BufferedIter = BufferedVec;
 
-    type SeqIterItem = T;
-
     type SeqIter = std::iter::Skip<std::vec::IntoIter<T>>;
 
     /// Converts the concurrent iterator back to the original wrapped type which is the source of the elements to be iterated.

--- a/tests/from_cloned_slice.rs
+++ b/tests/from_cloned_slice.rs
@@ -81,7 +81,7 @@ fn into_seq_iter_used_singly() {
 
     assert_eq!(seq_iter.len(), 1024 - 114);
     for (i, x) in seq_iter.enumerate() {
-        assert_eq!(x, &(114 + i).to_string());
+        assert_eq!(x, (114 + i).to_string());
     }
 }
 
@@ -107,7 +107,7 @@ fn into_seq_iter_used_in_batches() {
 
     assert_eq!(seq_iter.len(), 1024 - 44 - 33);
     for (i, x) in seq_iter.enumerate() {
-        assert_eq!(x, &(44 + 33 + i).to_string());
+        assert_eq!(x, (44 + 33 + i).to_string());
     }
 }
 
@@ -135,6 +135,6 @@ fn into_seq_iter_doc() {
 
     assert_eq!(seq_iter.len(), 1024 - num_used);
     for (i, x) in seq_iter.enumerate() {
-        assert_eq!(x, &(num_used + i).to_string());
+        assert_eq!(x, (num_used + i).to_string());
     }
 }


### PR DESCRIPTION
Sequential iter created back from a concurrent iterator yields the same element type as the concurrent version.

Fixes #30