### PR TITLE
`ConcurrentIter::has_more` is implemented

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-iter"
-version = "1.13.1"
+version = "1.14.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A thread-safe, ergonomic and lightweight concurrent iterator trait and efficient implementations."

--- a/src/has_more.rs
+++ b/src/has_more.rs
@@ -1,0 +1,15 @@
+/// Returns whether or not the concurrent iterator has more elements to yield.
+/// Response is guaranteed to be true.
+///
+/// * `Yes(n)`: the iterator will certainly yield `n` more elements.
+/// * `Maybe`: the iterator might or might not yield any more element. A concurrent iterator created from an iterator with a non-trivial filter could be considered as an example. There certainly exists elements to evaluate, but not guaranteed to return one.
+/// * `No`: the iterator has terminated, and will certainly not yield any more elements.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HasMore {
+    /// The iterator will certainly yield `n` more elements.
+    Yes(usize),
+    /// The iterator might or might not yield any more element. A concurrent iterator created from an iterator with a non-trivial filter could be considered as an example. There certainly exists elements to evaluate, but not guaranteed to return one.
+    Maybe,
+    /// The iterator has terminated, and will certainly not yield any more elements.
+    No,
+}

--- a/src/iter/implementors/iter.rs
+++ b/src/iter/implementors/iter.rs
@@ -231,7 +231,10 @@ where
 
     #[inline(always)]
     fn try_get_len(&self) -> Option<usize> {
-        None
+        match self.completed.load(atomic::Ordering::SeqCst) {
+            true => Some(0),
+            false => None,
+        }
     }
 
     fn skip_to_end(&self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,10 +321,12 @@
     clippy::todo
 )]
 
+mod has_more;
 /// Module defining concurrent iterator traits and implementations.
 pub mod iter;
 mod next;
 
+pub use has_more::HasMore;
 pub use iter::atomic_counter::AtomicCounter;
 pub use iter::con_iter::{ConcurrentIter, ExactSizeConcurrentIter};
 pub use iter::constructors::con_iterable::ConcurrentIterable;

--- a/tests/from_iter.rs
+++ b/tests/from_iter.rs
@@ -50,10 +50,10 @@ fn len() {
     assert_eq!(con_iter.try_get_len(), None);
 
     _ = con_iter.next();
-    assert_eq!(con_iter.try_get_len(), None);
+    assert_eq!(con_iter.try_get_len(), Some(0));
 
     _ = con_iter.next();
-    assert_eq!(con_iter.try_get_len(), None);
+    assert_eq!(con_iter.try_get_len(), Some(0));
 }
 
 #[test]


### PR DESCRIPTION
Not all iterators have this information exactly due to multiple reasons.
*  `ExactSizeConcurrentIter`s know exactly how many elements are there to yield. Therefore, they can give an exact answer.
* `ConcurrentIter`s built out of non-exact size `Iterator`s, such as iterators with a `filter`, does not exactly know how many more elements to be iterated over.
  * If the underlying iterator has not yet ended, it might or might not yield any more elements.
  * However, when the underlying iterator terminated, it can give the exact "no" answer.

In either case, the concurrent iterator is able to provide an exact "no" answer. This answer is already very useful for parallel processing, which could prevent spawning unnecessary threads.

An idea could be to return the following enum:

```rust
enum HasMore {
    Yes(usize),
    Maybe,
    No,
}
```

Closes #32