### PR TITLE
Bug leading to concurrent iterator created from a range with a non-ze…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-iter"
-version = "1.14.0"
+version = "1.15.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A thread-safe, ergonomic and lightweight concurrent iterator trait and efficient implementations."

--- a/src/iter/implementors/range.rs
+++ b/src/iter/implementors/range.rs
@@ -243,7 +243,7 @@ where
     /// ```
     fn into_seq_iter(self) -> Self::SeqIter {
         let current = self.counter().current();
-        current.into()..self.range.end
+        (self.range.start + current.into())..self.range.end
     }
 
     #[inline(always)]

--- a/tests/from_array.rs
+++ b/tests/from_array.rs
@@ -1,4 +1,5 @@
 use orx_concurrent_iter::*;
+use test_case::test_matrix;
 
 #[test]
 fn con_iter() {
@@ -159,4 +160,38 @@ fn into_seq_iter_doc() {
     for (i, x) in seq_iter.enumerate() {
         assert_eq!(x, num_used + i);
     }
+}
+
+#[test]
+fn into_seq_iter_not_used() {
+    let mut values = [0; 1024];
+    for (i, x) in values.iter_mut().enumerate() {
+        *x = i;
+    }
+    let iter = values.clone().into_con_iter().into_seq_iter();
+    let result: Vec<_> = iter.collect();
+
+    assert_eq!(result, values);
+}
+
+#[test_matrix([1, 10, 100])]
+fn into_seq_iter_used(take: usize) {
+    let mut values = [0; 1024];
+    for (i, x) in values.iter_mut().enumerate() {
+        *x = i;
+    }
+
+    let iter = values.clone().into_con_iter();
+    for _ in 0..take {
+        _ = iter.next();
+    }
+    let result: Vec<_> = iter.into_seq_iter().collect();
+
+    let mut iter = values.into_iter();
+    for _ in 0..take {
+        _ = iter.next();
+    }
+    let expected: Vec<_> = iter.collect();
+
+    assert_eq!(result, expected);
 }

--- a/tests/from_cloned_slice.rs
+++ b/tests/from_cloned_slice.rs
@@ -1,4 +1,5 @@
 use orx_concurrent_iter::*;
+use test_case::test_matrix;
 
 #[test]
 fn con_iter() {
@@ -137,4 +138,34 @@ fn into_seq_iter_doc() {
     for (i, x) in seq_iter.enumerate() {
         assert_eq!(x, (num_used + i).to_string());
     }
+}
+
+#[test_matrix([1, 8, 64, 1025, 5483])]
+fn into_seq_iter_not_used(len: usize) {
+    let values: Vec<_> = (100..(100 + len)).collect();
+    let slice = values.as_slice();
+    let iter = slice.con_iter().cloned().into_seq_iter();
+    let result: Vec<_> = iter.collect();
+
+    assert_eq!(result, values);
+}
+
+#[test_matrix([1, 8, 64, 1025, 5483], [1, 10, 100, ])]
+fn into_seq_iter_used(len: usize, take: usize) {
+    let values: Vec<_> = (100..(100 + len)).collect();
+
+    let slice = values.as_slice();
+    let iter = slice.con_iter().cloned();
+    for _ in 0..take {
+        _ = iter.next();
+    }
+    let result: Vec<_> = iter.into_seq_iter().collect();
+
+    let mut iter = values.into_iter();
+    for _ in 0..take {
+        _ = iter.next();
+    }
+    let expected: Vec<_> = iter.collect();
+
+    assert_eq!(result, expected);
 }

--- a/tests/from_iter.rs
+++ b/tests/from_iter.rs
@@ -1,4 +1,5 @@
 use orx_concurrent_iter::*;
+use test_case::test_matrix;
 
 #[test]
 fn con_iter() {
@@ -139,4 +140,38 @@ fn into_seq_iter_doc() {
     for (i, x) in seq_iter.enumerate() {
         assert_eq!(x, (num_used + i).to_string());
     }
+}
+
+#[test_matrix([1, 8, 64, 1025, 5483])]
+fn into_seq_iter_not_used(len: usize) {
+    let values: Vec<_> = (100..(100 + len)).collect();
+    let iter = values
+        .iter()
+        .filter(|x| *x % 2 == 0)
+        .into_con_iter()
+        .into_seq_iter();
+    let result: Vec<_> = iter.map(|x| *x).collect();
+
+    let expected: Vec<_> = values.into_iter().filter(|x| x % 2 == 0).collect();
+
+    assert_eq!(result, expected);
+}
+
+#[test_matrix([1, 8, 64, 1025, 5483], [1, 10, 100, ])]
+fn into_seq_iter_used(len: usize, take: usize) {
+    let values: Vec<_> = (100..(100 + len)).collect();
+
+    let iter = values.iter().filter(|x| *x % 2 == 0).into_con_iter();
+    for _ in 0..take {
+        _ = iter.next();
+    }
+    let result: Vec<_> = iter.into_seq_iter().map(|x| *x).collect();
+
+    let mut iter = values.into_iter().filter(|x| x % 2 == 0);
+    for _ in 0..take {
+        _ = iter.next();
+    }
+    let expected: Vec<_> = iter.collect();
+
+    assert_eq!(result, expected);
 }

--- a/tests/from_range.rs
+++ b/tests/from_range.rs
@@ -1,4 +1,5 @@
 use orx_concurrent_iter::*;
+use test_case::test_matrix;
 
 #[test]
 fn con_iter() {
@@ -149,4 +150,31 @@ fn into_seq_iter_doc() {
     for (i, x) in seq_iter.enumerate() {
         assert_eq!(x, num_used + i);
     }
+}
+
+#[test_matrix([0, 42], [0, 1, 42, 43, 100])]
+fn into_seq_iter_not_used(begin: usize, end: usize) {
+    let range = || begin..end;
+    let iter = range().con_iter().into_seq_iter();
+    assert_eq!(iter, range());
+}
+
+#[test_matrix([0, 42], [0, 1, 42, 43, 100], [1, 10, 100])]
+fn into_seq_iter_used(begin: usize, end: usize, take: usize) {
+    let range = || begin..end;
+
+    let iter = range().con_iter();
+    for _ in 0..take {
+        _ = iter.next();
+    }
+    let remaining: Vec<_> = iter.into_seq_iter().collect();
+
+    let vec: Vec<_> = range().collect();
+    let mut iter = vec.into_iter();
+    for _ in 0..take {
+        _ = iter.next();
+    }
+    let expected: Vec<_> = iter.collect();
+
+    assert_eq!(remaining, expected);
 }

--- a/tests/from_slice.rs
+++ b/tests/from_slice.rs
@@ -1,4 +1,5 @@
 use orx_concurrent_iter::*;
+use test_case::test_matrix;
 
 #[test]
 fn con_iter() {
@@ -144,4 +145,34 @@ fn into_seq_iter_doc() {
     for (i, x) in seq_iter.enumerate() {
         assert_eq!(x, &(num_used + i).to_string());
     }
+}
+
+#[test_matrix([1, 8, 64, 1025, 5483])]
+fn into_seq_iter_not_used(len: usize) {
+    let values: Vec<_> = (100..(100 + len)).collect();
+    let slice = values.as_slice();
+    let iter = slice.con_iter().into_seq_iter();
+    let result: Vec<_> = iter.map(|x| *x).collect();
+
+    assert_eq!(result, values);
+}
+
+#[test_matrix([1, 8, 64, 1025, 5483], [1, 10, 100, ])]
+fn into_seq_iter_used(len: usize, take: usize) {
+    let values: Vec<_> = (100..(100 + len)).collect();
+
+    let slice = values.as_slice();
+    let iter = slice.con_iter();
+    for _ in 0..take {
+        _ = iter.next();
+    }
+    let result: Vec<_> = iter.into_seq_iter().map(|x| *x).collect();
+
+    let mut iter = values.into_iter();
+    for _ in 0..take {
+        _ = iter.next();
+    }
+    let expected: Vec<_> = iter.collect();
+
+    assert_eq!(result, expected);
 }

--- a/tests/from_vec.rs
+++ b/tests/from_vec.rs
@@ -1,4 +1,5 @@
 use orx_concurrent_iter::*;
+use test_case::test_matrix;
 
 #[test]
 fn con_iter() {
@@ -147,4 +148,32 @@ fn into_seq_iter_doc() {
     for (i, x) in seq_iter.enumerate() {
         assert_eq!(x, (num_used + i).to_string());
     }
+}
+
+#[test_matrix([1, 8, 64, 1025, 5483])]
+fn into_seq_iter_not_used(len: usize) {
+    let values: Vec<_> = (100..(100 + len)).collect();
+    let iter = values.clone().into_con_iter().into_seq_iter();
+    let result: Vec<_> = iter.collect();
+
+    assert_eq!(result, values);
+}
+
+#[test_matrix([1, 8, 64, 1025, 5483], [1, 10, 100, ])]
+fn into_seq_iter_used(len: usize, take: usize) {
+    let values: Vec<_> = (100..(100 + len)).collect();
+
+    let iter = values.clone().into_con_iter();
+    for _ in 0..take {
+        _ = iter.next();
+    }
+    let result: Vec<_> = iter.into_seq_iter().collect();
+
+    let mut iter = values.into_iter();
+    for _ in 0..take {
+        _ = iter.next();
+    }
+    let expected: Vec<_> = iter.collect();
+
+    assert_eq!(result, expected);
 }


### PR DESCRIPTION
Bug leading to concurrent iterator created from a range with a non-zero starting point is fixed.

Bug leading to concurrent iterator created from a range with a non-zero starting point is fixed. The issue was only observed when the concurrent iterator is converted back to a sequential error.

Fixes #34