### PR TITLE
fix: buffered-iter-fix-for-range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-iter"
-version = "1.15.0"
+version = "1.16.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A thread-safe, ergonomic and lightweight concurrent iterator trait and efficient implementations."

--- a/src/iter/buffered/range.rs
+++ b/src/iter/buffered/range.rs
@@ -40,13 +40,11 @@ where
         begin_idx: usize,
     ) -> Option<impl ExactSizeIterator<Item = Idx>> {
         let range = iter.range();
-        let begin_value = range.start + begin_idx.into();
-
-        match begin_value.cmp(&range.end) {
+        let begin_value = begin_idx + range.start.into();
+        match begin_value.cmp(&range.end.into()) {
             Ordering::Less => {
-                let end_value = (begin_value + self.chunk_size.into()).min(range.end);
-                let end_idx: usize = (end_value - range.start).into();
-                let values = (begin_idx..end_idx).map(Idx::from);
+                let end_value = (begin_value + self.chunk_size).min(range.end.into());
+                let values = (begin_value..end_value).map(Idx::from);
                 Some(values)
             }
             _ => None,

--- a/src/iter/implementors/range.rs
+++ b/src/iter/implementors/range.rs
@@ -115,20 +115,17 @@ where
         let begin_idx = self
             .progress_and_get_begin_idx(n)
             .unwrap_or(self.initial_len());
-
-        let begin_value = self.range.start + begin_idx.into();
-
-        let end_value = match begin_value.cmp(&self.range.end) {
-            Ordering::Less => (begin_value + n.into()).min(self.range.end),
+        let begin_value = begin_idx + self.range.start.into();
+        let end_value = match begin_value.cmp(&self.range.end.into()) {
+            Ordering::Less => (begin_value + n).min(self.range.end.into()),
             _ => begin_value,
         };
-
-        let end_idx: usize = (end_value - self.range.start).into();
+        let end_idx: usize = end_value - self.range.start.into();
 
         match begin_idx.cmp(&end_idx) {
             Ordering::Equal => None,
             _ => {
-                let values = (begin_idx..end_idx).map(Idx::from);
+                let values = (begin_value..end_value).map(Idx::from);
                 Some(NextChunk { begin_idx, values })
             }
         }
@@ -154,7 +151,9 @@ where
 {
     #[inline(always)]
     fn initial_len(&self) -> usize {
-        (self.range.end - self.range.start).into()
+        let start: usize = self.range.start.into();
+        let end: usize = self.range.end.into();
+        end.saturating_sub(start)
     }
 }
 

--- a/tests/from_array.rs
+++ b/tests/from_array.rs
@@ -195,3 +195,23 @@ fn into_seq_iter_used(take: usize) {
 
     assert_eq!(result, expected);
 }
+
+#[test_matrix([1, 10, 100])]
+fn buffered(chunk_size: usize) {
+    let mut values = [0; 1024];
+    for (i, x) in values.iter_mut().enumerate() {
+        *x = 100 + i;
+    }
+    let iter = values.into_con_iter();
+    let mut buffered = iter.buffered_iter(chunk_size);
+
+    let mut current = 100;
+    while let Some(chunk) = buffered.next() {
+        for value in chunk.values {
+            assert_eq!(value, current);
+            current += 1;
+        }
+    }
+
+    assert_eq!(current, 100 + 1024);
+}

--- a/tests/from_cloned_slice.rs
+++ b/tests/from_cloned_slice.rs
@@ -169,3 +169,20 @@ fn into_seq_iter_used(len: usize, take: usize) {
 
     assert_eq!(result, expected);
 }
+
+#[test_matrix([1, 8, 64, 1025, 5483], [1, 10, 100])]
+fn buffered(len: usize, chunk_size: usize) {
+    let values: Vec<_> = (100..(100 + len)).collect();
+    let iter = values.con_iter().cloned();
+    let mut buffered = iter.buffered_iter(chunk_size);
+
+    let mut current = 100;
+    while let Some(chunk) = buffered.next() {
+        for value in chunk.values {
+            assert_eq!(value, current);
+            current += 1;
+        }
+    }
+
+    assert_eq!(current, 100 + len);
+}

--- a/tests/from_iter.rs
+++ b/tests/from_iter.rs
@@ -175,3 +175,20 @@ fn into_seq_iter_used(len: usize, take: usize) {
 
     assert_eq!(result, expected);
 }
+
+#[test_matrix([1, 8, 64, 1025, 5483], [1, 10, 100])]
+fn buffered(len: usize, chunk_size: usize) {
+    let values: Vec<_> = (100..(100 + len)).collect();
+    let iter = values.iter().filter(|x| **x > 115).into_con_iter();
+    let mut buffered = iter.buffered_iter(chunk_size);
+
+    let mut current = 116;
+    while let Some(chunk) = buffered.next() {
+        for value in chunk.values {
+            assert_eq!(value, &current);
+            current += 1;
+        }
+    }
+
+    assert_eq!(current, (100 + len).max(116));
+}

--- a/tests/from_range.rs
+++ b/tests/from_range.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+
 use orx_concurrent_iter::*;
 use test_case::test_matrix;
 
@@ -177,4 +179,23 @@ fn into_seq_iter_used(begin: usize, end: usize, take: usize) {
     let expected: Vec<_> = iter.collect();
 
     assert_eq!(remaining, expected);
+}
+
+#[test_matrix([0, 42], [0, 1, 42, 43, 100], [1, 10, 100])]
+fn buffered(begin: usize, end: usize, chunk_size: usize) {
+    let iter = (begin..end).con_iter();
+    let mut buffered = iter.buffered_iter(chunk_size);
+
+    let mut current = begin;
+    while let Some(chunk) = buffered.next() {
+        for value in chunk.values {
+            assert_eq!(value, current);
+            current += 1;
+        }
+    }
+
+    match end.cmp(&begin) {
+        Ordering::Less => assert_eq!(current, begin),
+        _ => assert_eq!(current, end),
+    }
 }

--- a/tests/from_slice.rs
+++ b/tests/from_slice.rs
@@ -176,3 +176,20 @@ fn into_seq_iter_used(len: usize, take: usize) {
 
     assert_eq!(result, expected);
 }
+
+#[test_matrix([1, 8, 64, 1025, 5483], [1, 10, 100])]
+fn buffered(len: usize, chunk_size: usize) {
+    let values: Vec<_> = (100..(100 + len)).collect();
+    let iter = values.con_iter();
+    let mut buffered = iter.buffered_iter(chunk_size);
+
+    let mut current = 100;
+    while let Some(chunk) = buffered.next() {
+        for value in chunk.values {
+            assert_eq!(value, &current);
+            current += 1;
+        }
+    }
+
+    assert_eq!(current, 100 + len);
+}

--- a/tests/from_vec.rs
+++ b/tests/from_vec.rs
@@ -159,7 +159,7 @@ fn into_seq_iter_not_used(len: usize) {
     assert_eq!(result, values);
 }
 
-#[test_matrix([1, 8, 64, 1025, 5483], [1, 10, 100, ])]
+#[test_matrix([1, 8, 64, 1025, 5483], [1, 10, 100])]
 fn into_seq_iter_used(len: usize, take: usize) {
     let values: Vec<_> = (100..(100 + len)).collect();
 
@@ -176,4 +176,21 @@ fn into_seq_iter_used(len: usize, take: usize) {
     let expected: Vec<_> = iter.collect();
 
     assert_eq!(result, expected);
+}
+
+#[test_matrix([1, 8, 64, 1025, 5483], [1, 10, 100])]
+fn buffered(len: usize, chunk_size: usize) {
+    let values: Vec<_> = (100..(100 + len)).collect();
+    let iter = values.into_con_iter();
+    let mut buffered = iter.buffered_iter(chunk_size);
+
+    let mut current = 100;
+    while let Some(chunk) = buffered.next() {
+        for value in chunk.values {
+            assert_eq!(value, current);
+            current += 1;
+        }
+    }
+
+    assert_eq!(current, 100 + len);
 }


### PR DESCRIPTION
BufferedIter of range iterator depends on start to be zero. Tests are extended for buffered iterators.

Fixes #36