### PR TITLE
ConIterOfIter safety

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-iter"
-version = "1.24.0"
+version = "1.25.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A thread-safe, ergonomic and lightweight concurrent iterator trait and efficient implementations."

--- a/src/iter/atomic_counter.rs
+++ b/src/iter/atomic_counter.rs
@@ -15,25 +15,25 @@ impl AtomicCounter {
     /// Fetches and returns the current value of the counter, and adds `len` to it.
     #[inline(always)]
     pub fn fetch_and_add(&self, len: usize) -> usize {
-        self.current.fetch_add(len, Ordering::AcqRel)
+        self.current.fetch_add(len, Ordering::Acquire)
     }
 
     /// Fetches and returns the current value of the counter, and adds `1` to it.
     #[inline(always)]
     pub fn fetch_and_increment(&self) -> usize {
-        self.current.fetch_add(1, Ordering::AcqRel)
+        self.current.fetch_add(1, Ordering::Acquire)
     }
 
     /// Fetches and returns the current value of the counter.
     #[inline(always)]
     pub fn current(&self) -> usize {
-        self.current.load(Ordering::Relaxed)
+        self.current.load(Ordering::Acquire)
     }
 
     /// Updates the value of the current value of the counter as the given `new_value`.
     #[inline(always)]
     pub fn store(&self, new_value: usize) {
-        self.current.store(new_value, Ordering::SeqCst)
+        self.current.store(new_value, Ordering::Release)
     }
 
     /// Updates the current value to the max of the current and provided `max_value`,

--- a/src/iter/implementors/iter_mut_handle.rs
+++ b/src/iter/implementors/iter_mut_handle.rs
@@ -1,0 +1,41 @@
+use super::iter_mut_states::*;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+pub(crate) struct IterMutHandle<'a> {
+    state: &'a AtomicU8,
+}
+
+impl<'a> IterMutHandle<'a> {
+    pub fn spin_get(state: &'a AtomicU8) -> Option<Self> {
+        loop {
+            match state.compare_exchange(
+                AVAILABLE,
+                IS_MUTATING,
+                Ordering::Acquire,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return Some(Self { state }),
+                Err(previous_state) => match previous_state {
+                    IS_MUTATING => continue,
+                    _/*COMPLETED*/ => return None,
+                },
+            }
+        }
+    }
+}
+
+impl<'a> Drop for IterMutHandle<'a> {
+    fn drop(&mut self) {
+        match self.state.compare_exchange(
+            IS_MUTATING,
+            AVAILABLE,
+            Ordering::Release,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => {}
+            Err(state) => {
+                assert_eq!(state, COMPLETED)
+            }
+        }
+    }
+}

--- a/src/iter/implementors/iter_mut_states.rs
+++ b/src/iter/implementors/iter_mut_states.rs
@@ -1,0 +1,3 @@
+pub(super) const AVAILABLE: u8 = 0;
+pub(super) const IS_MUTATING: u8 = 1;
+pub(super) const COMPLETED: u8 = 2;

--- a/src/iter/implementors/mod.rs
+++ b/src/iter/implementors/mod.rs
@@ -1,4 +1,7 @@
 pub mod iter;
+// pub mod iter2;
+mod iter_mut_handle;
+mod iter_mut_states;
 pub mod range;
 pub mod slice;
 pub mod vec;

--- a/tests/array_as_slice.rs
+++ b/tests/array_as_slice.rs
@@ -2,7 +2,7 @@ use orx_concurrent_iter::*;
 use test_case::test_matrix;
 
 const N: usize = 1024;
-const NUM_RERUNS: usize = 10;
+const NUM_RERUNS: usize = 1;
 
 fn concurrent_iter_stack(
     num_threads: usize,

--- a/tests/con_iter.rs
+++ b/tests/con_iter.rs
@@ -21,6 +21,7 @@ where
                         bag.push((next.idx, next.value));
                     }
                 }
+
                 if t % 2 == 0 {
                     while let Some(chunk) = iter.next_chunk(batch) {
                         for (i, value) in chunk.values.enumerate() {
@@ -197,7 +198,7 @@ where
 }
 
 #[test_matrix(
-    [1, 4, 1024, 64*1024],
+    [1, 4, 1024, 4*1024],
     [1, 2, 8],
     [1, 4, 64, 1024]
 )]
@@ -221,7 +222,7 @@ fn con_iter_slice(len: usize, num_threads: usize, batch: usize) {
 }
 
 #[test_matrix(
-    [1, 4, 1024, 64*1024],
+    [1, 4, 1024, 4*1024],
     [1, 2, 8],
     [1, 4, 64, 1024]
 )]
@@ -242,7 +243,7 @@ fn con_iter_vec(len: usize, num_threads: usize, batch: usize) {
 }
 
 #[test_matrix(
-    [1, 4, 1024, 64*1024],
+    [1, 4, 1024, 4*1024],
     [1, 2, 8],
     [1, 4, 64, 1024]
 )]

--- a/tests/from_range.rs
+++ b/tests/from_range.rs
@@ -1,6 +1,5 @@
-use std::cmp::Ordering;
-
 use orx_concurrent_iter::*;
+use std::cmp::Ordering;
 use test_case::test_matrix;
 
 #[test]

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -1,5 +1,4 @@
 mod atomic;
-
 use atomic::{atomic_fetch_n, atomic_fetch_one, ATOMIC_FETCH_N, ATOMIC_TEST_LEN};
 use orx_concurrent_iter::*;
 

--- a/tests/range.rs
+++ b/tests/range.rs
@@ -1,5 +1,4 @@
 mod atomic;
-
 use atomic::{
     atomic_fetch_n, atomic_fetch_one, atomic_initial_len, test_ids_and_values, test_values,
     ATOMIC_FETCH_N, ATOMIC_TEST_LEN,


### PR DESCRIPTION
* iter mut handle is introduced to guarantee preventing any race condition
* prior completed flag is replaced with the state field. state of the iterator can have either of the three possible values: AVAILABLE, IS_MUTATING and COMPLETED.