### PR TITLE
Relaxing send trait bound on concurrent slice iterator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-iter"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2024"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A thread-safe and ergonomic concurrent iterator trait and efficient lock-free implementations."

--- a/src/implementations/jagged_arrays/reference/chunk_puller.rs
+++ b/src/implementations/jagged_arrays/reference/chunk_puller.rs
@@ -6,7 +6,7 @@ use crate::{
 
 pub struct ChunkPullerJaggedRef<'i, 'a, T, S, X>
 where
-    T: Send + Sync,
+    T: Sync,
     X: JaggedIndexer + Send + Sync,
     S: Slices<'a, T> + Send + Sync,
 {
@@ -16,7 +16,7 @@ where
 
 impl<'i, 'a, T, S, X> ChunkPullerJaggedRef<'i, 'a, T, S, X>
 where
-    T: Send + Sync,
+    T: Sync,
     X: JaggedIndexer + Send + Sync,
     S: Slices<'a, T> + Send + Sync,
 {
@@ -30,7 +30,7 @@ where
 
 impl<'a, T, S, X> ChunkPuller for ChunkPullerJaggedRef<'_, 'a, T, S, X>
 where
-    T: Send + Sync + 'a,
+    T: Sync + 'a,
     X: JaggedIndexer + Send + Sync,
     S: Slices<'a, T> + Send + Sync,
 {

--- a/src/implementations/jagged_arrays/reference/con_iter.rs
+++ b/src/implementations/jagged_arrays/reference/con_iter.rs
@@ -11,7 +11,7 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 /// Flattened concurrent iterator of a raw jagged array yielding references to elements.
 pub struct ConIterJaggedRef<'a, T, S, X>
 where
-    T: Send + Sync + 'a,
+    T: Sync + 'a,
     X: JaggedIndexer,
     S: Slices<'a, T> + Send + Sync,
 {
@@ -21,7 +21,7 @@ where
 
 impl<'a, T, S, X> ConIterJaggedRef<'a, T, S, X>
 where
-    T: Send + Sync + 'a,
+    T: Sync + 'a,
     X: JaggedIndexer + Send + Sync,
     S: Slices<'a, T> + Send + Sync,
 {
@@ -58,7 +58,7 @@ where
 
 impl<'a, T, S, X> ConcurrentIter for ConIterJaggedRef<'a, T, S, X>
 where
-    T: Send + Sync + 'a,
+    T: Sync + 'a,
     X: JaggedIndexer,
     S: Slices<'a, T> + Send + Sync,
 {
@@ -105,7 +105,7 @@ where
 
 impl<'a, T, S, X> ExactSizeConcurrentIter for ConIterJaggedRef<'a, T, S, X>
 where
-    T: Send + Sync + 'a,
+    T: Sync + 'a,
     X: JaggedIndexer,
     S: Slices<'a, T> + Send + Sync,
 {

--- a/src/implementations/jagged_arrays/reference/into_con_iter.rs
+++ b/src/implementations/jagged_arrays/reference/into_con_iter.rs
@@ -6,7 +6,7 @@ use crate::{
 
 impl<'a, T, S, X> IntoConcurrentIter for RawJaggedRef<'a, T, S, X>
 where
-    T: Send + Sync + 'a,
+    T: Sync + 'a,
     X: JaggedIndexer,
     S: Slices<'a, T> + Send + Sync,
 {

--- a/src/implementations/range/tests/mod.rs
+++ b/src/implementations/range/tests/mod.rs
@@ -1,3 +1,4 @@
 mod con_iter;
 mod into;
+mod trait_bounds;
 mod transformations;

--- a/src/implementations/range/tests/trait_bounds.rs
+++ b/src/implementations/range/tests/trait_bounds.rs
@@ -1,0 +1,23 @@
+use core::ops::Range;
+
+fn into_con_iter<T: Send + Sync + From<usize> + Into<usize>>(range: Range<T>)
+where
+    Range<T>: Default + Clone + ExactSizeIterator<Item = T>,
+{
+    use crate::IntoConcurrentIter;
+    let _con_iter = range.into_con_iter();
+}
+
+fn concurrent_iterable<T: Send + Sync + From<usize> + Into<usize>>(range: Range<T>)
+where
+    Range<T>: Default + Clone + ExactSizeIterator<Item = T>,
+{
+    use crate::ConcurrentIterable;
+    let _con_iter = range.con_iter();
+}
+
+#[test]
+fn slice_con_iter_trait_bounds() {
+    into_con_iter(0..1);
+    concurrent_iterable(0..1);
+}

--- a/src/implementations/range/tests/trait_bounds.rs
+++ b/src/implementations/range/tests/trait_bounds.rs
@@ -17,7 +17,7 @@ where
 }
 
 #[test]
-fn slice_con_iter_trait_bounds() {
+fn range_con_iter_trait_bounds() {
     into_con_iter(0..1);
     concurrent_iterable(0..1);
 }

--- a/src/implementations/slice/chunk_puller.rs
+++ b/src/implementations/slice/chunk_puller.rs
@@ -3,7 +3,7 @@ use crate::pullers::ChunkPuller;
 
 pub struct ChunkPullerSlice<'i, 'a, T>
 where
-    T: Send + Sync,
+    T: Sync,
 {
     con_iter: &'i ConIterSlice<'a, T>,
     chunk_size: usize,
@@ -11,7 +11,7 @@ where
 
 impl<'i, 'a, T> ChunkPullerSlice<'i, 'a, T>
 where
-    T: Send + Sync,
+    T: Sync,
 {
     pub(super) fn new(con_iter: &'i ConIterSlice<'a, T>, chunk_size: usize) -> Self {
         Self {
@@ -23,7 +23,7 @@ where
 
 impl<'a, T> ChunkPuller for ChunkPullerSlice<'_, 'a, T>
 where
-    T: Send + Sync,
+    T: Sync,
 {
     type ChunkItem = &'a T;
 

--- a/src/implementations/slice/con_iter.rs
+++ b/src/implementations/slice/con_iter.rs
@@ -37,7 +37,7 @@ use core::{
 /// ```
 pub struct ConIterSlice<'a, T>
 where
-    T: Send + Sync,
+    T: Sync,
 {
     slice: &'a [T],
     counter: AtomicUsize,
@@ -45,7 +45,7 @@ where
 
 impl<T> Default for ConIterSlice<'_, T>
 where
-    T: Send + Sync,
+    T: Sync,
 {
     fn default() -> Self {
         Self::new(&[])
@@ -54,7 +54,7 @@ where
 
 impl<'a, T> ConIterSlice<'a, T>
 where
-    T: Send + Sync,
+    T: Sync,
 {
     pub(crate) fn new(slice: &'a [T]) -> Self {
         Self {
@@ -88,7 +88,7 @@ where
 
 impl<'a, T> ConcurrentIter for ConIterSlice<'a, T>
 where
-    T: Send + Sync,
+    T: Sync,
 {
     type Item = &'a T;
 
@@ -131,7 +131,7 @@ where
 
 impl<T> ExactSizeConcurrentIter for ConIterSlice<'_, T>
 where
-    T: Send + Sync,
+    T: Sync,
 {
     fn len(&self) -> usize {
         let num_taken = self.counter.load(Ordering::Acquire);

--- a/src/implementations/slice/into_con_iter.rs
+++ b/src/implementations/slice/into_con_iter.rs
@@ -3,7 +3,7 @@ use crate::{concurrent_iterable::ConcurrentIterable, into_concurrent_iter::IntoC
 
 impl<'a, T> IntoConcurrentIter for &'a [T]
 where
-    T: Send + Sync,
+    T: Sync,
 {
     type Item = &'a T;
 
@@ -16,7 +16,7 @@ where
 
 impl<'a, T> ConcurrentIterable for &'a [T]
 where
-    T: Send + Sync,
+    T: Sync,
 {
     type Item = &'a T;
 

--- a/src/implementations/slice/tests/mod.rs
+++ b/src/implementations/slice/tests/mod.rs
@@ -1,3 +1,4 @@
 mod con_iter;
 mod into;
+mod trait_bounds;
 mod transformations;

--- a/src/implementations/slice/tests/trait_bounds.rs
+++ b/src/implementations/slice/tests/trait_bounds.rs
@@ -1,0 +1,15 @@
+fn into_con_iter<T: Sync>(slice: &[T]) {
+    use crate::IntoConcurrentIter;
+    let _con_iter = slice.into_con_iter();
+}
+
+fn concurrent_iterable<T: Sync>(slice: &[T]) {
+    use crate::ConcurrentIterable;
+    let _con_iter = slice.con_iter();
+}
+
+#[test]
+fn slice_con_iter_trait_bounds() {
+    into_con_iter(&[1, 2, 4]);
+    concurrent_iterable(&[1, 2, 4]);
+}

--- a/src/implementations/vec/into_con_iter.rs
+++ b/src/implementations/vec/into_con_iter.rs
@@ -17,7 +17,7 @@ where
 
 impl<'a, T> IntoConcurrentIter for &'a Vec<T>
 where
-    T: Send + Sync,
+    T: Sync,
 {
     type Item = &'a T;
 

--- a/src/implementations/vec/tests/mod.rs
+++ b/src/implementations/vec/tests/mod.rs
@@ -1,3 +1,4 @@
 mod con_iter;
 mod into;
+mod trait_bounds;
 mod transformations;

--- a/src/implementations/vec/tests/trait_bounds.rs
+++ b/src/implementations/vec/tests/trait_bounds.rs
@@ -1,0 +1,25 @@
+use alloc::vec::Vec;
+
+fn into_con_iter<T: Send + Sync>(vec: Vec<T>) {
+    use crate::IntoConcurrentIter;
+    let _con_iter = vec.into_con_iter();
+}
+
+fn concurrent_iterable<T: Send + Sync>(vec: Vec<T>) {
+    use crate::ConcurrentIterable;
+    let vec_ref = &vec;
+    let _con_iter = vec_ref.con_iter();
+}
+
+fn concurrent_collection<T: Send + Sync>(vec: Vec<T>) {
+    use crate::ConcurrentCollection;
+    let _con_iter = vec.con_iter();
+    let _con_iter = vec.as_concurrent_iterable();
+}
+
+#[test]
+fn vec_con_iter_trait_bounds() {
+    into_con_iter(Vec::<String>::new());
+    concurrent_iterable(Vec::<String>::new());
+    concurrent_collection(Vec::<String>::new());
+}

--- a/src/implementations/vec_deque/con_iter_ref.rs
+++ b/src/implementations/vec_deque/con_iter_ref.rs
@@ -39,14 +39,14 @@ use orx_pseudo_default::PseudoDefault;
 /// ```
 pub struct ConIterVecDequeRef<'a, T>
 where
-    T: Send + Sync,
+    T: Sync,
 {
     con_iter: ConIterCore<'a, T>,
 }
 
 impl<'a, T> ConIterVecDequeRef<'a, T>
 where
-    T: Send + Sync,
+    T: Sync,
 {
     pub(super) fn new(vec_deque_ref: &'a VecDeque<T>) -> Self {
         let len = vec_deque_ref.len();
@@ -95,7 +95,7 @@ impl JaggedIndexer for VecDequeSlicesIndexer {
 
 impl<'a, T> ConcurrentIter for ConIterVecDequeRef<'a, T>
 where
-    T: Send + Sync,
+    T: Sync,
 {
     type Item = <ConIterCore<'a, T> as ConcurrentIter>::Item;
 
@@ -133,7 +133,7 @@ where
 
 impl<T> ExactSizeConcurrentIter for ConIterVecDequeRef<'_, T>
 where
-    T: Send + Sync,
+    T: Sync,
 {
     fn len(&self) -> usize {
         self.con_iter.len()

--- a/src/implementations/vec_deque/into_con_iter.rs
+++ b/src/implementations/vec_deque/into_con_iter.rs
@@ -4,7 +4,7 @@ use alloc::{collections::VecDeque, vec::Vec};
 
 impl<'a, T> IntoConcurrentIter for &'a VecDeque<T>
 where
-    T: Send + Sync,
+    T: Sync,
 {
     type Item = &'a T;
 

--- a/src/implementations/vec_deque/tests/mod.rs
+++ b/src/implementations/vec_deque/tests/mod.rs
@@ -1,3 +1,4 @@
 mod con_iter_ref;
 mod into;
+mod trait_bounds;
 mod transformations;

--- a/src/implementations/vec_deque/tests/trait_bounds.rs
+++ b/src/implementations/vec_deque/tests/trait_bounds.rs
@@ -1,0 +1,25 @@
+use std::collections::VecDeque;
+
+fn into_con_iter<T: Send + Sync>(vec: VecDeque<T>) {
+    use crate::IntoConcurrentIter;
+    let _con_iter = vec.into_con_iter();
+}
+
+fn concurrent_iterable<T: Send + Sync>(vec: VecDeque<T>) {
+    use crate::ConcurrentIterable;
+    let vec_ref = &vec;
+    let _con_iter = vec_ref.con_iter();
+}
+
+fn concurrent_collection<T: Send + Sync>(vec: VecDeque<T>) {
+    use crate::ConcurrentCollection;
+    let _con_iter = vec.con_iter();
+    let _con_iter = vec.as_concurrent_iterable();
+}
+
+#[test]
+fn vec_con_iter_trait_bounds() {
+    into_con_iter(VecDeque::<String>::new());
+    concurrent_iterable(VecDeque::<String>::new());
+    concurrent_collection(VecDeque::<String>::new());
+}

--- a/src/implementations/vec_deque/tests/trait_bounds.rs
+++ b/src/implementations/vec_deque/tests/trait_bounds.rs
@@ -18,7 +18,7 @@ fn concurrent_collection<T: Send + Sync>(vec: VecDeque<T>) {
 }
 
 #[test]
-fn vec_con_iter_trait_bounds() {
+fn vec_deque_con_iter_trait_bounds() {
     into_con_iter(VecDeque::<String>::new());
     concurrent_iterable(VecDeque::<String>::new());
     concurrent_collection(VecDeque::<String>::new());

--- a/src/implementations/vec_drain/tests/mod.rs
+++ b/src/implementations/vec_drain/tests/mod.rs
@@ -1,2 +1,3 @@
 mod con_iter;
+mod trait_bounds;
 mod transformations;

--- a/src/implementations/vec_drain/tests/trait_bounds.rs
+++ b/src/implementations/vec_drain/tests/trait_bounds.rs
@@ -1,0 +1,11 @@
+use alloc::vec::Vec;
+
+fn con_drain<T: Send + Sync>(mut vec: Vec<T>) {
+    use crate::ConcurrentDrainableOverSlice;
+    let _con_iter = vec.con_drain(..);
+}
+
+#[test]
+fn vec_drain_con_iter_trait_bounds() {
+    con_drain(Vec::<String>::new());
+}


### PR DESCRIPTION
In the prior implementation; however, `ConIterSlice<'a, T>` requires `T: Send + Sync`. Here, `Send` is an unnecessary requirement since the iterator will yield items of `&'a T` which automatically implements `Send` when `T` implements `Sync`.

Due to this unnecessary bound, the following code would not compile in the prior version:

```rust
fn fun<T: Sync>(slice: &[T]) {
    let con_iter = slice.into_con_iter();
}
```

with the error:

```bash
  |
7 |     let con_iter = slice.into_con_iter();
  |                          ^^^^^^^^^^^^^
  |
  = note: the following trait bounds were not satisfied:
          `T: Send`
          which is required by `&[T]: orx_concurrent_iter::IntoConcurrentIter`
help: consider restricting the type parameter to satisfy the trait bound
  |
6 | fn fun<T: Sync>(slice: &[T]) where T: Send {
  |                              +++++++++++++
```


With the fix, the function `fun` now compiles, as it should.

This is the downstream fix related to the "orx-parallel" issues:
* https://github.com/orxfun/orx-parallel/issues/58
* https://github.com/orxfun/orx-parallel/issues/59
