### PR TITLE
V4 handle pulling many items

### DIFF
--- a/src/chain/tests/con_iter.rs
+++ b/src/chain/tests/con_iter.rs
@@ -1094,8 +1094,9 @@ fn into_seq_iter(n: usize, nt: usize, until: usize) {
 #[test_matrix([0, 1, 100, 1000, 1500], [false, true])]
 fn pull_too_many(pulled_before: usize, by_idx: bool) {
     let n = 1234;
-    let v1 = || new_vec(n / 3, |x| (x + 10).to_string());
-    let v2 = || new_vec(n - n / 3, |x| (n / 3 + x + 10).to_string());
+    let v1_len = n / 3;
+    let v1 = || new_vec(v1_len, |x| (x + 10).to_string());
+    let v2 = || new_vec(n - v1_len, |x| (n / 3 + x + 10).to_string());
     let iter = ChainKnownLenI::new(v1().into_con_iter(), v2().into_con_iter(), n / 3);
 
     for _ in 0..pulled_before {
@@ -1103,11 +1104,16 @@ fn pull_too_many(pulled_before: usize, by_idx: bool) {
     }
 
     let mut puller = iter.chunk_puller_by(usize::MAX, 0);
-    let remaining = match by_idx {
+    let pulled = match by_idx {
         false => puller.pull().map(|iter| iter.count()),
         true => puller.pull_with_idx().map(|(_, iter)| iter.count()),
     }
     .unwrap_or(0);
 
-    assert_eq!(remaining, n.saturating_sub(pulled_before));
+    let expected = match pulled_before < v1_len {
+        true => v1_len - pulled_before,
+        false => n.saturating_sub(pulled_before),
+    };
+
+    assert_eq!(pulled, expected);
 }

--- a/src/chain/tests/con_iter.rs
+++ b/src/chain/tests/con_iter.rs
@@ -1090,3 +1090,24 @@ fn into_seq_iter(n: usize, nt: usize, until: usize) {
         until,
     );
 }
+
+#[test_matrix([0, 1, 100, 1000, 1500], [false, true])]
+fn pull_too_many(pulled_before: usize, by_idx: bool) {
+    let n = 1234;
+    let v1 = || new_vec(n / 3, |x| (x + 10).to_string());
+    let v2 = || new_vec(n - n / 3, |x| (n / 3 + x + 10).to_string());
+    let iter = ChainKnownLenI::new(v1().into_con_iter(), v2().into_con_iter(), n / 3);
+
+    for _ in 0..pulled_before {
+        _ = iter.next();
+    }
+
+    let mut puller = iter.chunk_puller_by(usize::MAX, 0);
+    let remaining = match by_idx {
+        false => puller.pull().map(|iter| iter.count()),
+        true => puller.pull_with_idx().map(|(_, iter)| iter.count()),
+    }
+    .unwrap_or(0);
+
+    assert_eq!(remaining, n.saturating_sub(pulled_before));
+}

--- a/src/implementations/empty/tests/con_iter.rs
+++ b/src/implementations/empty/tests/con_iter.rs
@@ -346,3 +346,22 @@ fn into_seq_iter() {
 
     assert_eq!(all, expected);
 }
+
+#[test_matrix([0, 1, 100, 1000, 1500], [false, true])]
+fn pull_too_many(pulled_before: usize, by_idx: bool) {
+    let n = 0usize;
+    let iter = ConIterEmpty::<String>::new();
+
+    for _ in 0..pulled_before {
+        _ = iter.next();
+    }
+
+    let mut puller = iter.chunk_puller_by(usize::MAX, 0);
+    let remaining = match by_idx {
+        false => puller.pull().map(|iter| iter.count()),
+        true => puller.pull_with_idx().map(|(_, iter)| iter.count()),
+    }
+    .unwrap_or(0);
+
+    assert_eq!(remaining, n.saturating_sub(pulled_before));
+}

--- a/src/implementations/iter/chunk_puller.rs
+++ b/src/implementations/iter/chunk_puller.rs
@@ -3,6 +3,8 @@ use crate::pullers::ChunkPuller;
 use alloc::vec::Vec;
 use core::iter::FusedIterator;
 
+pub(super) const MAX_CHUNK_SIZE: usize = 1 << 10;
+
 pub struct ChunkPullerOfIter<'i, I>
 where
     I: Iterator,
@@ -19,6 +21,7 @@ where
     I::Item: Send,
 {
     pub(super) fn new(con_iter: &'i ConIterOfIter<I>, chunk_size: usize) -> Self {
+        let chunk_size = chunk_size.min(MAX_CHUNK_SIZE);
         let mut buffer = Vec::with_capacity(chunk_size);
         for _ in 0..chunk_size {
             buffer.push(None);

--- a/src/implementations/iter/tests/con_iter.rs
+++ b/src/implementations/iter/tests/con_iter.rs
@@ -1,12 +1,8 @@
-use crate::{
-    concurrent_iter::ConcurrentIter, exact_size_concurrent_iter::ExactSizeConcurrentIter,
-    implementations::ConIterOfIter, pullers::ChunkPuller,
-};
-use alloc::{
-    format,
-    string::{String, ToString},
-    vec::Vec,
-};
+use crate::implementations::iter::chunk_puller::MAX_CHUNK_SIZE;
+use crate::{concurrent_iter::ConcurrentIter, exact_size_concurrent_iter::ExactSizeConcurrentIter};
+use crate::{implementations::ConIterOfIter, pullers::ChunkPuller};
+use alloc::string::{String, ToString};
+use alloc::{format, vec::Vec};
 use orx_concurrent_bag::ConcurrentBag;
 use test_case::test_matrix;
 
@@ -510,4 +506,27 @@ fn into_seq_iter(n: usize, nt: usize, until: usize) {
     expected.sort();
 
     assert_eq!(all, expected);
+}
+
+#[test_matrix([0, 1, 100, 1000, 1500], [false, true])]
+fn pull_too_many(pulled_before: usize, by_idx: bool) {
+    let n = 1234;
+    let vec = new_vec(n, |x| (x + 10).to_string());
+    let iter = ConIterOfIter::new(vec.into_iter().filter(|x| x.as_str() != "abc"));
+
+    for _ in 0..pulled_before {
+        _ = iter.next();
+    }
+
+    let mut puller = iter.chunk_puller_by(usize::MAX, 0);
+    let remaining = match by_idx {
+        false => puller.pull().map(|iter| iter.count()),
+        true => puller.pull_with_idx().map(|(_, iter)| iter.count()),
+    }
+    .unwrap_or(0);
+
+    assert_eq!(
+        remaining,
+        n.saturating_sub(pulled_before).min(MAX_CHUNK_SIZE)
+    );
 }

--- a/src/implementations/jagged_arrays/owned/con_iter.rs
+++ b/src/implementations/jagged_arrays/owned/con_iter.rs
@@ -1,10 +1,7 @@
-use super::{
-    chunk_puller::ChunkPullerJaggedOwned, into_iter::RawJaggedIterOwned, raw_jagged::RawJagged,
-    slice_iter::RawJaggedSliceIterOwned,
-};
-use crate::{
-    ConcurrentIter, ExactSizeConcurrentIter, implementations::jagged_arrays::indexer::JaggedIndexer,
-};
+use super::{chunk_puller::ChunkPullerJaggedOwned, into_iter::RawJaggedIterOwned};
+use super::{raw_jagged::RawJagged, slice_iter::RawJaggedSliceIterOwned};
+use crate::implementations::jagged_arrays::indexer::JaggedIndexer;
+use crate::{ConcurrentIter, ExactSizeConcurrentIter};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 /// Flattened concurrent iterator of a raw jagged array yielding owned elements.
@@ -46,7 +43,6 @@ where
         &self,
         chunk_size: usize,
     ) -> Option<(usize, RawJaggedSliceIterOwned<'_, T>)> {
-        let chunk_size = chunk_size.min(self.jagged.len());
         self.progress_and_get_begin_idx(chunk_size)
             .map(|begin_idx| {
                 let end_idx = (begin_idx + chunk_size)
@@ -113,6 +109,7 @@ where
     }
 
     fn chunk_puller(&self, chunk_size: usize) -> Self::ChunkPuller<'_> {
+        let chunk_size = chunk_size.min(self.jagged.len());
         Self::ChunkPuller::new(self, chunk_size)
     }
 }

--- a/src/implementations/jagged_arrays/owned/con_iter.rs
+++ b/src/implementations/jagged_arrays/owned/con_iter.rs
@@ -46,6 +46,7 @@ where
         &self,
         chunk_size: usize,
     ) -> Option<(usize, RawJaggedSliceIterOwned<'_, T>)> {
+        let chunk_size = chunk_size.min(self.jagged.len());
         self.progress_and_get_begin_idx(chunk_size)
             .map(|begin_idx| {
                 let end_idx = (begin_idx + chunk_size)

--- a/src/implementations/jagged_arrays/owned/tests/con_iter.rs
+++ b/src/implementations/jagged_arrays/owned/tests/con_iter.rs
@@ -503,3 +503,25 @@ fn into_seq_iter(n: usize, nt: usize, until: usize) {
 
     assert_eq!(all, expected);
 }
+
+#[test_matrix([0, 1, 100, 1000, 1500], [false, true])]
+fn pull_too_many(pulled_before: usize, by_idx: bool) {
+    let n = 1234;
+    let matrix = get_matrix(n);
+    let arrays: Vec<_> = matrix.into_iter().map(RawVec::from).collect();
+    let jagged = RawJagged::new(arrays, MatrixIndexer::new(n), Some(n * n));
+    let iter = ConIterJaggedOwned::new(jagged, 0);
+
+    for _ in 0..pulled_before {
+        _ = iter.next();
+    }
+
+    let mut puller = iter.chunk_puller_by(usize::MAX, 0);
+    let remaining = match by_idx {
+        false => puller.pull().map(|iter| iter.count()),
+        true => puller.pull_with_idx().map(|(_, iter)| iter.count()),
+    }
+    .unwrap_or(0);
+
+    assert_eq!(remaining, n.saturating_sub(pulled_before));
+}

--- a/src/implementations/jagged_arrays/owned/tests/con_iter.rs
+++ b/src/implementations/jagged_arrays/owned/tests/con_iter.rs
@@ -506,10 +506,11 @@ fn into_seq_iter(n: usize, nt: usize, until: usize) {
 
 #[test_matrix([0, 1, 100, 1000, 1500], [false, true])]
 fn pull_too_many(pulled_before: usize, by_idx: bool) {
-    let n = 1234;
-    let matrix = get_matrix(n);
+    let m = 35;
+    let n = m * m; // 1225
+    let matrix = get_matrix(m);
     let arrays: Vec<_> = matrix.into_iter().map(RawVec::from).collect();
-    let jagged = RawJagged::new(arrays, MatrixIndexer::new(n), Some(n * n));
+    let jagged = RawJagged::new(arrays, MatrixIndexer::new(m), Some(m * m));
     let iter = ConIterJaggedOwned::new(jagged, 0);
 
     for _ in 0..pulled_before {

--- a/src/implementations/jagged_arrays/reference/con_iter.rs
+++ b/src/implementations/jagged_arrays/reference/con_iter.rs
@@ -52,6 +52,7 @@ where
         &self,
         chunk_size: usize,
     ) -> Option<(usize, RawJaggedSliceIterRef<'a, T, S, X>)> {
+        let chunk_size = chunk_size.min(self.jagged.len());
         self.progress_and_get_begin_idx(chunk_size)
             .map(|begin_idx| {
                 let end_idx = (begin_idx + chunk_size)

--- a/src/implementations/jagged_arrays/reference/con_iter.rs
+++ b/src/implementations/jagged_arrays/reference/con_iter.rs
@@ -40,6 +40,11 @@ where
         }
     }
 
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.jagged.len()
+    }
+
     fn progress_and_get_begin_idx(&self, number_to_fetch: usize) -> Option<usize> {
         let begin_idx = self.counter.fetch_add(number_to_fetch, Ordering::Relaxed);
         match begin_idx < self.jagged.len() {
@@ -52,7 +57,6 @@ where
         &self,
         chunk_size: usize,
     ) -> Option<(usize, RawJaggedSliceIterRef<'a, T, S, X>)> {
-        let chunk_size = chunk_size.min(self.jagged.len());
         self.progress_and_get_begin_idx(chunk_size)
             .map(|begin_idx| {
                 let end_idx = (begin_idx + chunk_size)

--- a/src/implementations/jagged_arrays/reference/con_iter.rs
+++ b/src/implementations/jagged_arrays/reference/con_iter.rs
@@ -1,11 +1,7 @@
-use super::{
-    chunk_puller::ChunkPullerJaggedRef, raw_jagged_ref::RawJaggedRef,
-    slice_iter::RawJaggedSliceIterRef,
-};
-use crate::{
-    ConcurrentIter, ExactSizeConcurrentIter,
-    implementations::jagged_arrays::{JaggedIndexer, Slices},
-};
+use super::slice_iter::RawJaggedSliceIterRef;
+use super::{chunk_puller::ChunkPullerJaggedRef, raw_jagged_ref::RawJaggedRef};
+use crate::implementations::jagged_arrays::{JaggedIndexer, Slices};
+use crate::{ConcurrentIter, ExactSizeConcurrentIter};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 /// Flattened concurrent iterator of a raw jagged array yielding references to elements.
@@ -38,11 +34,6 @@ where
             jagged,
             counter: begin.into(),
         }
-    }
-
-    #[inline(always)]
-    pub fn len(&self) -> usize {
-        self.jagged.len()
     }
 
     fn progress_and_get_begin_idx(&self, number_to_fetch: usize) -> Option<usize> {
@@ -116,6 +107,7 @@ where
     }
 
     fn chunk_puller(&self, chunk_size: usize) -> Self::ChunkPuller<'_> {
+        let chunk_size = chunk_size.min(self.jagged.len());
         Self::ChunkPuller::new(self, chunk_size)
     }
 }

--- a/src/implementations/jagged_arrays/reference/tests/con_iter.rs
+++ b/src/implementations/jagged_arrays/reference/tests/con_iter.rs
@@ -488,3 +488,24 @@ fn into_seq_iter(n: usize, nt: usize, until: usize) {
 
     assert_eq!(all, expected);
 }
+
+#[test_matrix([0, 1, 100, 1000, 1500], [false, true])]
+fn pull_too_many(pulled_before: usize, by_idx: bool) {
+    let n = 1234;
+    let matrix = get_matrix(n);
+    let jagged = RawJaggedRef::new(matrix.as_slice(), MatrixIndexer::new(n), Some(n * n));
+    let iter = ConIterJaggedRef::new(jagged, 0);
+
+    for _ in 0..pulled_before {
+        _ = iter.next();
+    }
+
+    let mut puller = iter.chunk_puller_by(usize::MAX, 0);
+    let remaining = match by_idx {
+        false => puller.pull().map(|iter| iter.count()),
+        true => puller.pull_with_idx().map(|(_, iter)| iter.count()),
+    }
+    .unwrap_or(0);
+
+    assert_eq!(remaining, n.saturating_sub(pulled_before));
+}

--- a/src/implementations/jagged_arrays/reference/tests/con_iter.rs
+++ b/src/implementations/jagged_arrays/reference/tests/con_iter.rs
@@ -491,9 +491,10 @@ fn into_seq_iter(n: usize, nt: usize, until: usize) {
 
 #[test_matrix([0, 1, 100, 1000, 1500], [false, true])]
 fn pull_too_many(pulled_before: usize, by_idx: bool) {
-    let n = 1234;
-    let matrix = get_matrix(n);
-    let jagged = RawJaggedRef::new(matrix.as_slice(), MatrixIndexer::new(n), Some(n * n));
+    let m = 35;
+    let n = m * m; // 1225
+    let matrix = get_matrix(m);
+    let jagged = RawJaggedRef::new(matrix.as_slice(), MatrixIndexer::new(m), Some(m * m));
     let iter = ConIterJaggedRef::new(jagged, 0);
 
     for _ in 0..pulled_before {

--- a/src/implementations/range/con_iter.rs
+++ b/src/implementations/range/con_iter.rs
@@ -85,10 +85,7 @@ where
     pub(super) fn progress_and_get_range(&self, chunk_size: usize) -> Option<(usize, T, T)> {
         self.progress_and_get_begin_idx(chunk_size)
             .map(|begin_idx| {
-                let end_idx = begin_idx
-                    .saturating_add(chunk_size)
-                    .min(self.len)
-                    .max(begin_idx);
+                let end_idx = (begin_idx + chunk_size).min(self.len).max(begin_idx);
                 let begin = self.begin + begin_idx;
                 let end = self.begin + end_idx;
                 (begin_idx, begin.into(), end.into())
@@ -142,6 +139,7 @@ where
     }
 
     fn chunk_puller(&self, chunk_size: usize) -> Self::ChunkPuller<'_> {
+        let chunk_size = chunk_size.min(self.len);
         (self, chunk_size).into()
     }
 }

--- a/src/implementations/range/con_iter.rs
+++ b/src/implementations/range/con_iter.rs
@@ -85,7 +85,10 @@ where
     pub(super) fn progress_and_get_range(&self, chunk_size: usize) -> Option<(usize, T, T)> {
         self.progress_and_get_begin_idx(chunk_size)
             .map(|begin_idx| {
-                let end_idx = (begin_idx + chunk_size).min(self.len).max(begin_idx);
+                let end_idx = begin_idx
+                    .saturating_add(chunk_size)
+                    .min(self.len)
+                    .max(begin_idx);
                 let begin = self.begin + begin_idx;
                 let end = self.begin + end_idx;
                 (begin_idx, begin.into(), end.into())

--- a/src/implementations/range/tests/con_iter.rs
+++ b/src/implementations/range/tests/con_iter.rs
@@ -439,3 +439,22 @@ fn into_seq_iter(n: usize, nt: usize, until: usize) {
 
     assert_eq!(all, expected);
 }
+
+#[test_matrix([0, 1, 100, 1000, 1500], [false, true])]
+fn pull_too_many(pulled_before: usize, by_idx: bool) {
+    let n = 1234;
+    let iter = ConIterRange::new(10..(10 + n));
+
+    for _ in 0..pulled_before {
+        _ = iter.next();
+    }
+
+    let mut puller = iter.chunk_puller_by(usize::MAX, 0);
+    let remaining = match by_idx {
+        false => puller.pull().map(|iter| iter.count()),
+        true => puller.pull_with_idx().map(|(_, iter)| iter.count()),
+    }
+    .unwrap_or(0);
+
+    assert_eq!(remaining, n.saturating_sub(pulled_before));
+}

--- a/src/implementations/slice/con_iter.rs
+++ b/src/implementations/slice/con_iter.rs
@@ -69,7 +69,8 @@ impl<'a, T> ConIterSlice<'a, T> {
     pub(super) fn progress_and_get_slice(&self, chunk_size: usize) -> Option<(usize, &'a [T])> {
         self.progress_and_get_begin_idx(chunk_size)
             .map(|begin_idx| {
-                let end_idx = (begin_idx + chunk_size)
+                let end_idx = begin_idx
+                    .saturating_add(chunk_size)
                     .min(self.slice.len())
                     .max(begin_idx);
                 (begin_idx, &self.slice[begin_idx..end_idx])

--- a/src/implementations/slice/con_iter.rs
+++ b/src/implementations/slice/con_iter.rs
@@ -69,8 +69,7 @@ impl<'a, T> ConIterSlice<'a, T> {
     pub(super) fn progress_and_get_slice(&self, chunk_size: usize) -> Option<(usize, &'a [T])> {
         self.progress_and_get_begin_idx(chunk_size)
             .map(|begin_idx| {
-                let end_idx = begin_idx
-                    .saturating_add(chunk_size)
+                let end_idx = (begin_idx + chunk_size)
                     .min(self.slice.len())
                     .max(begin_idx);
                 (begin_idx, &self.slice[begin_idx..end_idx])
@@ -121,6 +120,7 @@ where
     }
 
     fn chunk_puller(&self, chunk_size: usize) -> Self::ChunkPuller<'_> {
+        let chunk_size = chunk_size.min(self.slice.len());
         Self::ChunkPuller::new(self, chunk_size)
     }
 }

--- a/src/implementations/slice/tests/con_iter.rs
+++ b/src/implementations/slice/tests/con_iter.rs
@@ -481,7 +481,7 @@ fn into_seq_iter(n: usize, nt: usize, until: usize) {
 }
 
 #[test_matrix([0, 1, 100, 1000, 1500], [false, true])]
-fn pull_too_many_xyz(pulled_before: usize, by_idx: bool) {
+fn pull_too_many(pulled_before: usize, by_idx: bool) {
     let n = 1234;
     let vec = new_vec(n, |x| (x + 10).to_string());
     let slice = vec.as_slice();

--- a/src/implementations/slice/tests/con_iter.rs
+++ b/src/implementations/slice/tests/con_iter.rs
@@ -1,3 +1,5 @@
+use core::usize;
+
 use crate::{
     concurrent_iter::ConcurrentIter, exact_size_concurrent_iter::ExactSizeConcurrentIter,
     implementations::slice::con_iter::ConIterSlice, pullers::ChunkPuller,
@@ -476,4 +478,25 @@ fn into_seq_iter(n: usize, nt: usize, until: usize) {
     expected.sort();
 
     assert_eq!(all, expected);
+}
+
+#[test_matrix([0, 1, 100, 1000, 1500], [false, true])]
+fn pull_too_many(pulled_before: usize, by_idx: bool) {
+    let n = 1234;
+    let vec = new_vec(n, |x| (x + 10).to_string());
+    let slice = vec.as_slice();
+    let iter = ConIterSlice::new(slice);
+
+    for _ in 0..pulled_before {
+        _ = iter.next();
+    }
+
+    let mut puller = iter.chunk_puller_by(usize::MAX, 0);
+    let remaining = match by_idx {
+        false => puller.pull().map(|iter| iter.count()),
+        true => puller.pull_with_idx().map(|(_, iter)| iter.count()),
+    }
+    .unwrap_or(0);
+
+    assert_eq!(remaining, n.saturating_sub(pulled_before));
 }

--- a/src/implementations/slice/tests/con_iter.rs
+++ b/src/implementations/slice/tests/con_iter.rs
@@ -481,7 +481,7 @@ fn into_seq_iter(n: usize, nt: usize, until: usize) {
 }
 
 #[test_matrix([0, 1, 100, 1000, 1500], [false, true])]
-fn pull_too_many(pulled_before: usize, by_idx: bool) {
+fn pull_too_many_xyz(pulled_before: usize, by_idx: bool) {
     let n = 1234;
     let vec = new_vec(n, |x| (x + 10).to_string());
     let slice = vec.as_slice();

--- a/src/implementations/slice/tests/con_iter.rs
+++ b/src/implementations/slice/tests/con_iter.rs
@@ -1,13 +1,7 @@
-use core::usize;
-
-use crate::{
-    concurrent_iter::ConcurrentIter, exact_size_concurrent_iter::ExactSizeConcurrentIter,
-    implementations::slice::con_iter::ConIterSlice, pullers::ChunkPuller,
-};
-use alloc::{
-    string::{String, ToString},
-    vec::Vec,
-};
+use crate::{concurrent_iter::ConcurrentIter, exact_size_concurrent_iter::ExactSizeConcurrentIter};
+use crate::{implementations::slice::con_iter::ConIterSlice, pullers::ChunkPuller};
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 use orx_concurrent_bag::ConcurrentBag;
 use test_case::test_matrix;
 

--- a/src/implementations/slice_mut/con_iter.rs
+++ b/src/implementations/slice_mut/con_iter.rs
@@ -88,7 +88,10 @@ impl<'a, T: 'a> ConIterSliceMut<'a, T> {
 
         self.progress_and_get_begin_idx(chunk_size)
             .map(|begin_idx| {
-                let end_idx = (begin_idx + chunk_size).min(slice_len).max(begin_idx);
+                let end_idx = begin_idx
+                    .saturating_add(chunk_size)
+                    .min(slice_len)
+                    .max(begin_idx);
 
                 let ptr = unsafe { self.p.add(begin_idx) };
                 let len = end_idx - begin_idx;

--- a/src/implementations/slice_mut/con_iter.rs
+++ b/src/implementations/slice_mut/con_iter.rs
@@ -88,10 +88,7 @@ impl<'a, T: 'a> ConIterSliceMut<'a, T> {
 
         self.progress_and_get_begin_idx(chunk_size)
             .map(|begin_idx| {
-                let end_idx = begin_idx
-                    .saturating_add(chunk_size)
-                    .min(slice_len)
-                    .max(begin_idx);
+                let end_idx = (begin_idx + chunk_size).min(slice_len).max(begin_idx);
 
                 let ptr = unsafe { self.p.add(begin_idx) };
                 let len = end_idx - begin_idx;
@@ -149,6 +146,7 @@ where
     }
 
     fn chunk_puller(&self, chunk_size: usize) -> Self::ChunkPuller<'_> {
+        let chunk_size = chunk_size.min(self.slice_len);
         Self::ChunkPuller::new(self, chunk_size)
     }
 }

--- a/src/implementations/slice_mut/tests/con_iter.rs
+++ b/src/implementations/slice_mut/tests/con_iter.rs
@@ -457,3 +457,24 @@ fn into_seq_iter(n: usize, nt: usize, until: usize) {
     };
     assert_eq!(expected, vec);
 }
+
+#[test_matrix([0, 1, 100, 1000, 1500], [false, true])]
+fn pull_too_many(pulled_before: usize, by_idx: bool) {
+    let n = 1234;
+    let mut vec = new_vec(n, |x| (x + 10).to_string());
+    let slice = vec.as_mut_slice();
+    let iter = ConIterSliceMut::new(slice);
+
+    for _ in 0..pulled_before {
+        _ = iter.next();
+    }
+
+    let mut puller = iter.chunk_puller_by(usize::MAX, 0);
+    let remaining = match by_idx {
+        false => puller.pull().map(|iter| iter.count()),
+        true => puller.pull_with_idx().map(|(_, iter)| iter.count()),
+    }
+    .unwrap_or(0);
+
+    assert_eq!(remaining, n.saturating_sub(pulled_before));
+}

--- a/src/implementations/vec/con_iter.rs
+++ b/src/implementations/vec/con_iter.rs
@@ -115,6 +115,7 @@ impl<T> ArrayConIter for ConIterVec<T> {
         &self,
         chunk_size: usize,
     ) -> Option<ChunkPointers<Self::Item>> {
+        let chunk_size = chunk_size.min(self.vec_len);
         self.progress_and_get_begin_idx(chunk_size)
             .map(|begin_idx| {
                 let end_idx = (begin_idx + chunk_size).min(self.vec_len).max(begin_idx);

--- a/src/implementations/vec/con_iter.rs
+++ b/src/implementations/vec/con_iter.rs
@@ -115,7 +115,6 @@ impl<T> ArrayConIter for ConIterVec<T> {
         &self,
         chunk_size: usize,
     ) -> Option<ChunkPointers<Self::Item>> {
-        let chunk_size = chunk_size.min(self.vec_len);
         self.progress_and_get_begin_idx(chunk_size)
             .map(|begin_idx| {
                 let end_idx = (begin_idx + chunk_size).min(self.vec_len).max(begin_idx);
@@ -174,6 +173,7 @@ where
     }
 
     fn chunk_puller(&self, chunk_size: usize) -> Self::ChunkPuller<'_> {
+        let chunk_size = chunk_size.min(self.vec_len);
         Self::ChunkPuller::new(self, chunk_size)
     }
 }

--- a/src/implementations/vec/tests/con_iter.rs
+++ b/src/implementations/vec/tests/con_iter.rs
@@ -463,3 +463,23 @@ fn into_seq_iter(n: usize, nt: usize, until: usize) {
 
     assert_eq!(all, expected);
 }
+
+#[test_matrix([0, 1, 100, 1000, 1500], [false, true])]
+fn pull_too_many(pulled_before: usize, by_idx: bool) {
+    let n = 1234;
+    let vec = new_vec(n, |x| (x + 10).to_string());
+    let iter = ConIterVec::new(vec);
+
+    for _ in 0..pulled_before {
+        _ = iter.next();
+    }
+
+    let mut puller = iter.chunk_puller_by(usize::MAX, 0);
+    let remaining = match by_idx {
+        false => puller.pull().map(|iter| iter.count()),
+        true => puller.pull_with_idx().map(|(_, iter)| iter.count()),
+    }
+    .unwrap_or(0);
+
+    assert_eq!(remaining, n.saturating_sub(pulled_before));
+}

--- a/src/implementations/vec_deque/con_iter_ref.rs
+++ b/src/implementations/vec_deque/con_iter_ref.rs
@@ -131,7 +131,6 @@ where
     }
 
     fn chunk_puller(&self, chunk_size: usize) -> Self::ChunkPuller<'_> {
-        let chunk_size = chunk_size.min(self.con_iter.len());
         self.con_iter.chunk_puller(chunk_size)
     }
 }

--- a/src/implementations/vec_deque/con_iter_ref.rs
+++ b/src/implementations/vec_deque/con_iter_ref.rs
@@ -131,6 +131,7 @@ where
     }
 
     fn chunk_puller(&self, chunk_size: usize) -> Self::ChunkPuller<'_> {
+        let chunk_size = chunk_size.min(self.con_iter.len());
         self.con_iter.chunk_puller(chunk_size)
     }
 }

--- a/src/implementations/vec_deque/tests/con_iter_ref.rs
+++ b/src/implementations/vec_deque/tests/con_iter_ref.rs
@@ -471,3 +471,23 @@ fn into_seq_iter(n: usize, nt: usize, until: usize) {
 
     assert_eq!(all, expected);
 }
+
+#[test_matrix([0, 1, 100, 1000, 1500], [false, true])]
+fn pull_too_many(pulled_before: usize, by_idx: bool) {
+    let n = 1234;
+    let vec = new_vec(n, |x| (x + 10).to_string());
+    let iter = ConIterVecDequeRef::new(&vec);
+
+    for _ in 0..pulled_before {
+        _ = iter.next();
+    }
+
+    let mut puller = iter.chunk_puller_by(usize::MAX, 0);
+    let remaining = match by_idx {
+        false => puller.pull().map(|iter| iter.count()),
+        true => puller.pull_with_idx().map(|(_, iter)| iter.count()),
+    }
+    .unwrap_or(0);
+
+    assert_eq!(remaining, n.saturating_sub(pulled_before));
+}

--- a/src/implementations/vec_deque/tests/con_iter_ref.rs
+++ b/src/implementations/vec_deque/tests/con_iter_ref.rs
@@ -473,7 +473,7 @@ fn into_seq_iter(n: usize, nt: usize, until: usize) {
 }
 
 #[test_matrix([0, 1, 100, 1000, 1500], [false, true])]
-fn pull_too_many_xyz(pulled_before: usize, by_idx: bool) {
+fn pull_too_many(pulled_before: usize, by_idx: bool) {
     let n = 1234;
     let vec = new_vec(n, |x| (x + 10).to_string());
     let iter = ConIterVecDequeRef::new(&vec);

--- a/src/implementations/vec_deque/tests/con_iter_ref.rs
+++ b/src/implementations/vec_deque/tests/con_iter_ref.rs
@@ -473,7 +473,7 @@ fn into_seq_iter(n: usize, nt: usize, until: usize) {
 }
 
 #[test_matrix([0, 1, 100, 1000, 1500], [false, true])]
-fn pull_too_many(pulled_before: usize, by_idx: bool) {
+fn pull_too_many_xyz(pulled_before: usize, by_idx: bool) {
     let n = 1234;
     let vec = new_vec(n, |x| (x + 10).to_string());
     let iter = ConIterVecDequeRef::new(&vec);

--- a/src/implementations/vec_drain/con_iter.rs
+++ b/src/implementations/vec_drain/con_iter.rs
@@ -225,6 +225,7 @@ where
     }
 
     fn chunk_puller(&self, chunk_size: usize) -> Self::ChunkPuller<'_> {
+        let chunk_size = chunk_size.min(self.vec_len);
         Self::ChunkPuller::new(self, chunk_size)
     }
 }

--- a/src/implementations/vec_drain/tests/con_iter.rs
+++ b/src/implementations/vec_drain/tests/con_iter.rs
@@ -484,3 +484,23 @@ fn into_seq_iter(n: usize, nt: usize, until: usize) {
 
     assert_eq!(all, expected);
 }
+
+#[test_matrix([0, 1, 100, 1000, 1500], [false, true])]
+fn pull_too_many(pulled_before: usize, by_idx: bool) {
+    let n = 1234;
+    let mut vec = new_vec(n, |x| (x + 10).to_string());
+    let iter = ConIterVecDrain::new(&mut vec, ..);
+
+    for _ in 0..pulled_before {
+        _ = iter.next();
+    }
+
+    let mut puller = iter.chunk_puller_by(usize::MAX, 0);
+    let remaining = match by_idx {
+        false => puller.pull().map(|iter| iter.count()),
+        true => puller.pull_with_idx().map(|(_, iter)| iter.count()),
+    }
+    .unwrap_or(0);
+
+    assert_eq!(remaining, n.saturating_sub(pulled_before));
+}


### PR DESCRIPTION
Enables requesting very large chunks, which will simply try to return all remaining elements at once.

This succeeds almost in all cases.

However, in chained iterators, we may still need to pull `n` chunks if there are `n` chained concurrent iterators.
